### PR TITLE
Hal reflection update

### DIFF
--- a/HAL-Base/HAL-Base.csproj
+++ b/HAL-Base/HAL-Base.csproj
@@ -25,9 +25,9 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
-    <Optimize>false</Optimize>
+    <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/HAL-Base/HAL-Base.csproj
+++ b/HAL-Base/HAL-Base.csproj
@@ -4,16 +4,16 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{D41E4184-C699-4F9C-9895-1915638AF9D7}</ProjectGuid>
+    <ProjectGuid>{BFCE384E-CA2A-4604-AF76-777DA91DAFEE}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>HAL_FRC</RootNamespace>
-    <AssemblyName>HAL-RoboRIO</AssemblyName>
+    <RootNamespace>HAL_Base</RootNamespace>
+    <AssemblyName>HAL-Base</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -23,6 +23,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Release\</OutputPath>
@@ -30,8 +31,15 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject />
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>
@@ -42,27 +50,18 @@
     <Compile Include="HALCANTalon.cs" />
     <Compile Include="HALCompressor.cs" />
     <Compile Include="HALDigital.cs" />
+    <Compile Include="HALInterrupts.cs" />
     <Compile Include="HALNotifier.cs" />
     <Compile Include="HALPDP.cs" />
     <Compile Include="HALPower.cs" />
     <Compile Include="HALSemaphore.cs" />
     <Compile Include="HALSerialPort.cs" />
     <Compile Include="HALSolenoid.cs" />
-    <Compile Include="HALInterrupts.cs" />
+    <Compile Include="HALUsageReporter.cs" />
     <Compile Include="HALUtilities.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\HAL-Base\HAL-Base.csproj">
-      <Project>{bfce384e-ca2a-4604-af76-777da91dafee}</Project>
-      <Name>HAL-Base</Name>
-    </ProjectReference>
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>
-    </PostBuildEvent>
-  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/HAL-Base/HAL.cs
+++ b/HAL-Base/HAL.cs
@@ -1,0 +1,410 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+
+
+namespace HAL_Base
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public enum HALAllianceStationID
+    {
+// ReSharper disable InconsistentNaming
+        HALAllianceStationID_red1,
+
+        HALAllianceStationID_red2,
+
+        HALAllianceStationID_red3,
+
+        HALAllianceStationID_blue1,
+
+        HALAllianceStationID_blue2,
+
+
+        HALAllianceStationID_blue3,
+// ReSharper restore InconsistentNaming
+    }
+
+    /// <summary>
+    /// Joystick Axes Struct
+    /// </summary>
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public struct HALJoystickAxes
+    {
+        /// unsigned short
+        public ushort count;
+
+        /// short[12]
+        [System.Runtime.InteropServices.MarshalAsAttribute(System.Runtime.InteropServices.UnmanagedType.ByValArray, SizeConst = 12, ArraySubType = System.Runtime.InteropServices.UnmanagedType.I2)]
+        public short[] axes;
+    }
+
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public struct HALJoystickPOVs
+    {
+        /// unsigned short
+        public ushort count;
+
+        /// short[12]
+        [System.Runtime.InteropServices.MarshalAsAttribute(System.Runtime.InteropServices.UnmanagedType.ByValArray, SizeConst = 12, ArraySubType = System.Runtime.InteropServices.UnmanagedType.I2)]
+        public short[] povs;
+    }
+
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
+    public struct HALJoystickButtons
+    {
+        /// unsigned int
+        public uint buttons;
+
+        /// byte
+        public byte count;
+    }
+
+    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, CharSet = System.Runtime.InteropServices.CharSet.Ansi)]
+    public struct HALJoystickDescriptor
+    {
+        /// byte
+        public byte isXbox;
+
+        /// byte
+        public byte type;
+
+        /// char[256]
+        [System.Runtime.InteropServices.MarshalAsAttribute(System.Runtime.InteropServices.UnmanagedType.ByValTStr, SizeConst = 256)]
+        public string name;
+
+        /// byte
+        public byte axisCount;
+
+        /// byte
+        public byte axisTypes;
+
+        /// byte
+        public byte buttonCount;
+
+        /// byte
+        public byte povCount;
+    }
+
+    public class HAL
+    {
+
+        internal static Assembly HALAssembly;
+
+        private static bool s_isSimulation = false;
+
+        /// <summary>
+        /// Gets or Sets if the code is in simulation mode
+        /// </summary>
+        public static bool IsSimulation
+        {
+            get
+            {
+                return s_isSimulation;
+            }
+            set { s_isSimulation = value; }
+        }
+
+        /// <summary>
+        /// This function is called in order to setup the delegates for the HAL functions.
+        /// </summary>
+        internal static void SetupDelegates()
+        {
+            if (HALAssembly == null)
+            {
+                throw new Exception(
+                    "HAL Assembly was not set. This is probalby an error in the WPILib. If you see contact the robotdotnet team.");
+            }
+            string className = MethodBase.GetCurrentMethod().DeclaringType.Name;
+            var types = HALAssembly.GetTypes();
+            var q = from t in types where t.IsClass && t.Name == className select t;
+
+            Type type = HAL.HALAssembly.GetType(q.ToList()[0].FullName);
+
+            GetPort = (GetPortDelegate)Delegate.CreateDelegate(typeof(GetPortDelegate), type.GetMethod("GetPort"));
+
+            GetPortWithModule = (GetPortWithModuleDelegate)Delegate.CreateDelegate(typeof(GetPortWithModuleDelegate), type.GetMethod("GetPortWithModule"));
+
+            GetHALErrorMessage = (GetHALErrorMessageDelegate)Delegate.CreateDelegate(typeof(GetHALErrorMessageDelegate), type.GetMethod("GetHALErrorMessage"));
+
+            GetFPGAVersion = (GetFPGAVersionDelegate)Delegate.CreateDelegate(typeof(GetFPGAVersionDelegate), type.GetMethod("GetFPGAVersion"));
+
+            GetFPGARevision = (GetFPGARevisionDelegate)Delegate.CreateDelegate(typeof(GetFPGARevisionDelegate), type.GetMethod("GetFPGARevision"));
+
+            GetFPGATime = (GetFPGATimeDelegate)Delegate.CreateDelegate(typeof(GetFPGATimeDelegate), type.GetMethod("GetFPGATime"));
+
+            GetFPGAButton = (GetFPGAButtonDelegate)Delegate.CreateDelegate(typeof(GetFPGAButtonDelegate), type.GetMethod("GetFPGAButton"));
+
+            SetErrorDataHAL = (SetErrorDataDelegate)Delegate.CreateDelegate(typeof(SetErrorDataDelegate), type.GetMethod("SetErrorData"));
+
+            GetControlWordHAL = (GetControlWordDelegate)Delegate.CreateDelegate(typeof(GetControlWordDelegate), type.GetMethod("GetControlWord"));
+
+            GetAllianceStation = (GetAllianceStationDelegate)Delegate.CreateDelegate(typeof(GetAllianceStationDelegate), type.GetMethod("GetAllianceStation"));
+
+            GetJoystickAxes = (GetJoystickAxesDelegate)Delegate.CreateDelegate(typeof(GetJoystickAxesDelegate), type.GetMethod("GetJoystickAxes"));
+
+            GetJoystickPOVs = (GetJoystickPOVsDelegate)Delegate.CreateDelegate(typeof(GetJoystickPOVsDelegate), type.GetMethod("GetJoystickPOVs"));
+
+            GetJoystickButtons = (GetJoystickButtonsDelegate)Delegate.CreateDelegate(typeof(GetJoystickButtonsDelegate), type.GetMethod("GetJoystickButtons"));
+
+            GetJoystickDescriptor = (GetJoystickDescriptorDelegate)Delegate.CreateDelegate(typeof(GetJoystickDescriptorDelegate), type.GetMethod("GetJoystickDescriptor"));
+
+            SetJoystickOutputs = (SetJoystickOutputsDelegate)Delegate.CreateDelegate(typeof(SetJoystickOutputsDelegate), type.GetMethod("SetJoystickOutputs"));
+
+            GetMatchTime = (GetMatchTimeDelegate)Delegate.CreateDelegate(typeof(GetMatchTimeDelegate), type.GetMethod("GetMatchTime"));
+
+            SetNewDataSem = (SetNewDataSemDelegate)Delegate.CreateDelegate(typeof(SetNewDataSemDelegate), type.GetMethod("SetNewDataSem"));
+
+            GetSystemActive = (GetSystemActiveDelegate)Delegate.CreateDelegate(typeof(GetSystemActiveDelegate), type.GetMethod("GetSystemActive"));
+
+            GetBrownedOut = (GetBrownedOutDelegate)Delegate.CreateDelegate(typeof(GetBrownedOutDelegate), type.GetMethod("GetBrownedOut"));
+
+            HALInitialize = (HALInitializeDelegate)Delegate.CreateDelegate(typeof(HALInitializeDelegate), type.GetMethod("HALInitialize"));
+
+            NetworkCommunicationObserveUserProgramStarting = (NetworkCommunicationObserveUserProgramStartingDelegate)Delegate.CreateDelegate(typeof(NetworkCommunicationObserveUserProgramStartingDelegate), type.GetMethod("NetworkCommunicationObserveUserProgramStarting"));
+
+            NetworkCommunicationObserveUserProgramDisabled = (NetworkCommunicationObserveUserProgramDisabledDelegate)Delegate.CreateDelegate(typeof(NetworkCommunicationObserveUserProgramDisabledDelegate), type.GetMethod("NetworkCommunicationObserveUserProgramDisabled"));
+
+            NetworkCommunicationObserveUserProgramAutonomous = (NetworkCommunicationObserveUserProgramAutonomousDelegate)Delegate.CreateDelegate(typeof(NetworkCommunicationObserveUserProgramAutonomousDelegate), type.GetMethod("NetworkCommunicationObserveUserProgramAutonomous"));
+
+            NetworkCommunicationObserveUserProgramTeleop = (NetworkCommunicationObserveUserProgramTeleopDelegate)Delegate.CreateDelegate(typeof(NetworkCommunicationObserveUserProgramTeleopDelegate), type.GetMethod("NetworkCommunicationObserveUserProgramTeleop"));
+
+            NetworkCommunicationObserveUserProgramTest = (NetworkCommunicationObserveUserProgramTestDelegate)Delegate.CreateDelegate(typeof(NetworkCommunicationObserveUserProgramTestDelegate), type.GetMethod("NetworkCommunicationObserveUserProgramTest"));
+
+            HALReport = (HALReportDelegate)Delegate.CreateDelegate(typeof(HALReportDelegate), type.GetMethod("HALReport"));
+
+            NumericArrayResize = (NumericArrayResizeDelegate)Delegate.CreateDelegate(typeof(NumericArrayResizeDelegate), type.GetMethod("NumericArrayResize"));
+
+            RTSetCleanupProc = (RTSetCleanupProcDelegate)Delegate.CreateDelegate(typeof(RTSetCleanupProcDelegate), type.GetMethod("RTSetCleanupProc"));
+
+            EDVR_CreateReference = (EDVR_CreateReferenceDelegate)Delegate.CreateDelegate(typeof(EDVR_CreateReferenceDelegate), type.GetMethod("EDVR_CreateReference"));
+
+            Occur = (OccurDelegate)Delegate.CreateDelegate(typeof(OccurDelegate), type.GetMethod("Occur"));
+        }
+
+        public delegate System.IntPtr GetPortDelegate(byte pin);
+        public static GetPortDelegate GetPort;
+
+        public delegate System.IntPtr GetPortWithModuleDelegate(byte module, byte pin);
+        public static GetPortWithModuleDelegate GetPortWithModule;
+
+        public delegate string GetHALErrorMessageDelegate(int code);
+        public static GetHALErrorMessageDelegate GetHALErrorMessage;
+
+        public delegate ushort GetFPGAVersionDelegate(ref int status);
+        public static GetFPGAVersionDelegate GetFPGAVersion;
+
+        public delegate uint GetFPGARevisionDelegate(ref int status);
+        public static GetFPGARevisionDelegate GetFPGARevision;
+
+        public delegate uint GetFPGATimeDelegate(ref int status);
+        public static GetFPGATimeDelegate GetFPGATime;
+
+        public delegate bool GetFPGAButtonDelegate(ref int status);
+        public static GetFPGAButtonDelegate GetFPGAButton;
+
+        public delegate int SetErrorDataDelegate([System.Runtime.InteropServices.InAttribute()] [System.Runtime.InteropServices.MarshalAsAttribute(System.Runtime.InteropServices.UnmanagedType.LPStr)] string errors, int errorsLength, int waitMs);
+        private static SetErrorDataDelegate SetErrorDataHAL;
+
+        public delegate int GetControlWordDelegate(ref uint data);
+        private static GetControlWordDelegate GetControlWordHAL;
+
+        public delegate int GetAllianceStationDelegate(ref HALAllianceStationID allianceStation);
+        public static GetAllianceStationDelegate GetAllianceStation;
+
+        public delegate int GetJoystickAxesDelegate(byte joystickNum, ref HALJoystickAxes axes);
+        public static GetJoystickAxesDelegate GetJoystickAxes;
+
+        public delegate int GetJoystickPOVsDelegate(byte joystickNum, ref HALJoystickPOVs povs);
+        public static GetJoystickPOVsDelegate GetJoystickPOVs;
+
+        public delegate int GetJoystickButtonsDelegate(byte joystickNum, ref HALJoystickButtons buttons);
+        public static GetJoystickButtonsDelegate GetJoystickButtons;
+
+        public delegate int GetJoystickDescriptorDelegate(byte joystickNum, ref HALJoystickDescriptor desc);
+        public static GetJoystickDescriptorDelegate GetJoystickDescriptor;
+
+        public delegate int SetJoystickOutputsDelegate(byte joystickNum, uint outputs, ushort leftRumble, ushort rightRumble);
+        public static SetJoystickOutputsDelegate SetJoystickOutputs;
+
+        public delegate int GetMatchTimeDelegate(ref float matchTime);
+        public static GetMatchTimeDelegate GetMatchTime;
+
+        public delegate void SetNewDataSemDelegate(System.IntPtr sem);
+        public static SetNewDataSemDelegate SetNewDataSem;
+
+        public delegate bool GetSystemActiveDelegate(ref int status);
+        public static GetSystemActiveDelegate GetSystemActive;
+
+        public delegate bool GetBrownedOutDelegate(ref int status);
+        public static GetBrownedOutDelegate GetBrownedOut;
+
+        public delegate int HALInitializeDelegate(int mode = 0);
+        public static HALInitializeDelegate HALInitialize;
+
+        public delegate void NetworkCommunicationObserveUserProgramStartingDelegate();
+        public static NetworkCommunicationObserveUserProgramStartingDelegate NetworkCommunicationObserveUserProgramStarting;
+
+        public delegate void NetworkCommunicationObserveUserProgramDisabledDelegate();
+        public static NetworkCommunicationObserveUserProgramDisabledDelegate NetworkCommunicationObserveUserProgramDisabled;
+
+        public delegate void NetworkCommunicationObserveUserProgramAutonomousDelegate();
+        public static NetworkCommunicationObserveUserProgramAutonomousDelegate NetworkCommunicationObserveUserProgramAutonomous;
+
+        public delegate void NetworkCommunicationObserveUserProgramTeleopDelegate();
+        public static NetworkCommunicationObserveUserProgramTeleopDelegate NetworkCommunicationObserveUserProgramTeleop;
+
+        public delegate void NetworkCommunicationObserveUserProgramTestDelegate();
+        public static NetworkCommunicationObserveUserProgramTestDelegate NetworkCommunicationObserveUserProgramTest;
+
+        public delegate uint HALReportDelegate(byte resource, byte instanceNumber, byte context = 0, [System.Runtime.InteropServices.InAttribute()] [System.Runtime.InteropServices.MarshalAsAttribute(System.Runtime.InteropServices.UnmanagedType.LPStr)] string feature = null);
+        public static HALReportDelegate HALReport;
+
+        public delegate void NumericArrayResizeDelegate();
+        public static NumericArrayResizeDelegate NumericArrayResize;
+
+        public delegate void RTSetCleanupProcDelegate();
+        public static RTSetCleanupProcDelegate RTSetCleanupProc;
+
+        public delegate void EDVR_CreateReferenceDelegate();
+        public static EDVR_CreateReferenceDelegate EDVR_CreateReference;
+
+        public delegate void OccurDelegate();
+        public static OccurDelegate Occur;
+
+
+        public static int SetErrorData(string errors, int waitMs)
+        {
+            return SetErrorDataHAL(errors, errors.Length, waitMs);
+        }
+
+        /// <summary>
+        /// HAL Initalization. Must be called before any other HAL functions.
+        /// </summary>
+        /// <param name="mode">Initialization Mode</param>
+        public static void Initialize(int mode = 0)
+        {
+            if (IsSimulation)
+            {
+                HALAssembly = Assembly.LoadFrom("/home/lvuser/mono/HAL-Simulation.dll");
+            }
+            else
+            {
+                HALAssembly = Assembly.LoadFrom("/home/lvuser/robotdotnet/HAL-RoboRIO.dll");
+            }
+
+            SetupDelegates();
+            HALAccelerometer.SetupDelegate();
+            HALAnalog.SetupDelegate();
+            HALCANTalon.SetupDelegate();
+            HALCompressor.SetupDelegate();
+            HALDigital.SetupDelegates();
+            HALInterrupts.SetupDelegates();
+            HALNotifier.SetupDelegates();
+            HALPDP.SetupDelegates();
+            HALPower.SetupDelegates();
+            HALSemaphore.SetupDelegates();
+            HALSerialPort.SetupDelegates();
+            HALSolenoid.SetupDelegates();
+            HALUtilities.SetupDelegates();
+
+
+            var rv = HALInitialize();
+            if (rv == 0)
+            {
+                throw new Exception("HAL Initialize Failed");
+            }
+        }
+
+
+        //Move to WPILib
+
+        public static uint Report(ResourceType resource, Instances instanceNumber, byte context = 0,
+            string feature = null)
+        {
+            return HALReport((byte)resource, (byte)instanceNumber, context, feature);
+        }
+
+        public static uint Report(ResourceType resource, byte instanceNumber, byte context = 0,
+            string feature = null)
+        {
+            return HALReport((byte)resource, instanceNumber, context, feature);
+        }
+
+        public static uint Report(byte resource, Instances instanceNumber, byte context = 0,
+            string feature = null)
+        {
+            return HALReport(resource, (byte)instanceNumber, context, feature);
+        }
+
+        public static uint Report(byte resource, byte instanceNumber, byte context = 0,
+            string feature = null)
+        {
+            return HALReport(resource, instanceNumber, context, feature);
+        }
+
+        /*
+        public static void CheckStatus(int status)
+        {
+            if (status < 0)
+            {
+                string message = GetHALErrorMessage(status);
+                throw new SystemException(" Code: " + status + ". " + message);
+            }
+            else if (status > 0)
+            {
+                string message = GetHALErrorMessage(status);
+                DriverStation.ReportError(message, true);
+            }
+        }
+         * */
+
+        public static HALControlWord GetControlWord()
+        {
+            uint temp = 0;
+            GetControlWordHAL(ref temp);
+            return new HALControlWord(temp);
+        }
+    }
+
+    public struct HALControlWord
+    {
+        private uint _wordData;
+
+        public HALControlWord(uint data)
+        {
+            _wordData = data;
+        }
+
+        public bool GetEnabled()
+        {
+            return (_wordData & (1 << 1 - 1)) != 0;
+        }
+
+        public bool GetAutonomous()
+        {
+            return (_wordData & (1 << 2 - 1)) != 0;
+        }
+
+        public bool GetTest()
+        {
+            return (_wordData & (1 << 3 - 1)) != 0;
+        }
+
+        public bool GetEStop()
+        {
+            return (_wordData & (1 << 4 - 1)) != 0;
+        }
+
+        public bool GetFMSAttached()
+        {
+            return (_wordData & (1 << 5 - 1)) != 0;
+        }
+
+        public bool GetDSAttached()
+        {
+            return (_wordData & (1 << 6 - 1)) != 0;
+        }
+    }
+}

--- a/HAL-Base/HALAccelerometer.cs
+++ b/HAL-Base/HALAccelerometer.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace HAL_Base
+{
+    public enum AccelerometerRange
+    {
+        /// kRange_2G -> 0
+        Range_2G = 0,
+
+        /// kRange_4G -> 1
+        Range_4G = 1,
+
+        /// kRange_8G -> 2
+        Range_8G = 2,
+    }
+
+    public class HALAccelerometer
+    {
+
+        internal static void SetupDelegate()
+        {
+            string className = MethodBase.GetCurrentMethod().DeclaringType.Name;
+            var types = HAL.HALAssembly.GetTypes();
+            var q = from t in types where t.IsClass && t.Name == className select t;
+
+            Type type = HAL.HALAssembly.GetType(q.ToList()[0].FullName);
+
+            SetAccelerometerActive = (SetAccelerometerActiveDelegate)Delegate.CreateDelegate(typeof(SetAccelerometerActiveDelegate), type.GetMethod("setAccelerometerActive"));
+
+            SetAccelerometerRange = (SetAccelerometerRangeDelegate)Delegate.CreateDelegate(typeof(SetAccelerometerRangeDelegate), type.GetMethod("setAccelerometerRange"));
+
+            GetAccelerometerX = (GetAccelerometerXDelegate)Delegate.CreateDelegate(typeof(GetAccelerometerXDelegate), type.GetMethod("getAccelerometerX"));
+
+            GetAccelerometerY = (GetAccelerometerYDelegate)Delegate.CreateDelegate(typeof(GetAccelerometerYDelegate), type.GetMethod("getAccelerometerY"));
+
+            GetAccelerometerZ = (GetAccelerometerZDelegate)Delegate.CreateDelegate(typeof(GetAccelerometerZDelegate), type.GetMethod("getAccelerometerZ"));
+        }
+
+        public delegate void SetAccelerometerActiveDelegate([System.Runtime.InteropServices.MarshalAsAttribute(System.Runtime.InteropServices.UnmanagedType.I1)] bool param0);
+        public static SetAccelerometerActiveDelegate SetAccelerometerActive;
+
+        public delegate void SetAccelerometerRangeDelegate(AccelerometerRange param0);
+        public static SetAccelerometerRangeDelegate SetAccelerometerRange;
+
+        public delegate double GetAccelerometerXDelegate();
+        public static GetAccelerometerXDelegate GetAccelerometerX;
+
+        public delegate double GetAccelerometerYDelegate();
+        public static GetAccelerometerYDelegate GetAccelerometerY;
+
+        public delegate double GetAccelerometerZDelegate();
+        public static GetAccelerometerZDelegate GetAccelerometerZ;
+
+    }
+}

--- a/HAL-Base/HALAnalog.cs
+++ b/HAL-Base/HALAnalog.cs
@@ -1,0 +1,248 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+
+namespace HAL_Base
+{
+    public enum AnalogTriggerType
+    {
+        /// kInWindow -> 0
+        InWindow = 0,
+
+        /// kState -> 1
+        State = 1,
+
+        /// kRisingPulse -> 2
+        RisingPulse = 2,
+
+        /// kFallingPulse -> 3
+        FallingPulse = 3,
+    }
+
+    public class HALAnalog
+    {
+        internal static void SetupDelegate()
+        {
+            string className = MethodBase.GetCurrentMethod().DeclaringType.Name;
+            var types = HAL.HALAssembly.GetTypes();
+            var q = from t in types where t.IsClass && t.Name == className select t;
+
+            Type type = HAL.HALAssembly.GetType(q.ToList()[0].FullName);
+
+            InitializeAnalogOutputPort = (InitializeAnalogOutputPortDelegate)Delegate.CreateDelegate(typeof(InitializeAnalogOutputPortDelegate), type.GetMethod("initializeAnalogOutputPort"));
+
+            SetAnalogOutput = (SetAnalogOutputDelegate)Delegate.CreateDelegate(typeof(SetAnalogOutputDelegate), type.GetMethod("setAnalogOutput"));
+
+            GetAnalogOutput = (GetAnalogOutputDelegate)Delegate.CreateDelegate(typeof(GetAnalogOutputDelegate), type.GetMethod("getAnalogOutput"));
+
+            CheckAnalogOutputChannel = (CheckAnalogOutputChannelDelegate)Delegate.CreateDelegate(typeof(CheckAnalogOutputChannelDelegate), type.GetMethod("checkAnalogOutputChannel"));
+
+            InitializeAnalogInputPort = (InitializeAnalogInputPortDelegate)Delegate.CreateDelegate(typeof(InitializeAnalogInputPortDelegate), type.GetMethod("initializeAnalogInputPort"));
+
+            CheckAnalogModule = (CheckAnalogModuleDelegate)Delegate.CreateDelegate(typeof(CheckAnalogModuleDelegate), type.GetMethod("checkAnalogModule"));
+
+            CheckAnalogInputChannel = (CheckAnalogInputChannelDelegate)Delegate.CreateDelegate(typeof(CheckAnalogInputChannelDelegate), type.GetMethod("checkAnalogInputChannel"));
+
+            SetAnalogSampleRate = (SetAnalogSampleRateDelegate)Delegate.CreateDelegate(typeof(SetAnalogSampleRateDelegate), type.GetMethod("setAnalogSampleRate"));
+
+            GetAnalogSampleRate = (GetAnalogSampleRateDelegate)Delegate.CreateDelegate(typeof(GetAnalogSampleRateDelegate), type.GetMethod("getAnalogSampleRate"));
+
+            SetAnalogAverageBits = (SetAnalogAverageBitsDelegate)Delegate.CreateDelegate(typeof(SetAnalogAverageBitsDelegate), type.GetMethod("setAnalogAverageBits"));
+
+            GetAnalogAverageBits = (GetAnalogAverageBitsDelegate)Delegate.CreateDelegate(typeof(GetAnalogAverageBitsDelegate), type.GetMethod("getAnalogAverageBits"));
+
+            SetAnalogOversampleBits = (SetAnalogOversampleBitsDelegate)Delegate.CreateDelegate(typeof(SetAnalogOversampleBitsDelegate), type.GetMethod("setAnalogOversampleBits"));
+
+            GetAnalogOversampleBits = (GetAnalogOversampleBitsDelegate)Delegate.CreateDelegate(typeof(GetAnalogOversampleBitsDelegate), type.GetMethod("getAnalogOversampleBits"));
+
+            GetAnalogValue = (GetAnalogValueDelegate)Delegate.CreateDelegate(typeof(GetAnalogValueDelegate), type.GetMethod("getAnalogValue"));
+
+            GetAnalogAverageValue = (GetAnalogAverageValueDelegate)Delegate.CreateDelegate(typeof(GetAnalogAverageValueDelegate), type.GetMethod("getAnalogAverageValue"));
+
+            GetAnalogVoltsToValue = (GetAnalogVoltsToValueDelegate)Delegate.CreateDelegate(typeof(GetAnalogVoltsToValueDelegate), type.GetMethod("getAnalogVoltsToValue"));
+
+            GetAnalogVoltage = (GetAnalogVoltageDelegate)Delegate.CreateDelegate(typeof(GetAnalogVoltageDelegate), type.GetMethod("getAnalogVoltage"));
+
+            GetAnalogAverageVoltage = (GetAnalogAverageVoltageDelegate)Delegate.CreateDelegate(typeof(GetAnalogAverageVoltageDelegate), type.GetMethod("getAnalogAverageVoltage"));
+
+            GetAnalogLSBWeight = (GetAnalogLSBWeightDelegate)Delegate.CreateDelegate(typeof(GetAnalogLSBWeightDelegate), type.GetMethod("getAnalogLSBWeight"));
+
+            GetAnalogOffset = (GetAnalogOffsetDelegate)Delegate.CreateDelegate(typeof(GetAnalogOffsetDelegate), type.GetMethod("getAnalogOffset"));
+
+            IsAccumulatorChannel = (IsAccumulatorChannelDelegate)Delegate.CreateDelegate(typeof(IsAccumulatorChannelDelegate), type.GetMethod("isAccumulatorChannel"));
+
+            InitAccumulator = (InitAccumulatorDelegate)Delegate.CreateDelegate(typeof(InitAccumulatorDelegate), type.GetMethod("initAccumulator"));
+
+            ResetAccumulator = (ResetAccumulatorDelegate)Delegate.CreateDelegate(typeof(ResetAccumulatorDelegate), type.GetMethod("resetAccumulator"));
+
+            SetAccumulatorCenter = (SetAccumulatorCenterDelegate)Delegate.CreateDelegate(typeof(SetAccumulatorCenterDelegate), type.GetMethod("setAccumulatorCenter"));
+
+            SetAccumulatorDeadband = (SetAccumulatorDeadbandDelegate)Delegate.CreateDelegate(typeof(SetAccumulatorDeadbandDelegate), type.GetMethod("setAccumulatorDeadband"));
+
+            GetAccumulatorValue = (GetAccumulatorValueDelegate)Delegate.CreateDelegate(typeof(GetAccumulatorValueDelegate), type.GetMethod("getAccumulatorValue"));
+
+            GetAccumulatorCount = (GetAccumulatorCountDelegate)Delegate.CreateDelegate(typeof(GetAccumulatorCountDelegate), type.GetMethod("getAccumulatorCount"));
+
+            GetAccumulatorOutput = (GetAccumulatorOutputDelegate)Delegate.CreateDelegate(typeof(GetAccumulatorOutputDelegate), type.GetMethod("getAccumulatorOutput"));
+
+            InitializeAnalogTrigger = (InitializeAnalogTriggerDelegate)Delegate.CreateDelegate(typeof(InitializeAnalogTriggerDelegate), type.GetMethod("initializeAnalogTrigger"));
+
+            CleanAnalogTrigger = (CleanAnalogTriggerDelegate)Delegate.CreateDelegate(typeof(CleanAnalogTriggerDelegate), type.GetMethod("cleanAnalogTrigger"));
+
+            SetAnalogTriggerLimitsRaw = (SetAnalogTriggerLimitsRawDelegate)Delegate.CreateDelegate(typeof(SetAnalogTriggerLimitsRawDelegate), type.GetMethod("setAnalogTriggerLimitsRaw"));
+
+            SetAnalogTriggerLimitsVoltage = (SetAnalogTriggerLimitsVoltageDelegate)Delegate.CreateDelegate(typeof(SetAnalogTriggerLimitsVoltageDelegate), type.GetMethod("setAnalogTriggerLimitsVoltage"));
+
+            SetAnalogTriggerAveraged = (SetAnalogTriggerAveragedDelegate)Delegate.CreateDelegate(typeof(SetAnalogTriggerAveragedDelegate), type.GetMethod("setAnalogTriggerAveraged"));
+
+            SetAnalogTriggerFiltered = (SetAnalogTriggerFilteredDelegate)Delegate.CreateDelegate(typeof(SetAnalogTriggerFilteredDelegate), type.GetMethod("setAnalogTriggerFiltered"));
+
+            GetAnalogTriggerInWindow = (GetAnalogTriggerInWindowDelegate)Delegate.CreateDelegate(typeof(GetAnalogTriggerInWindowDelegate), type.GetMethod("getAnalogTriggerInWindow"));
+
+            GetAnalogTriggerTriggerState = (GetAnalogTriggerTriggerStateDelegate)Delegate.CreateDelegate(typeof(GetAnalogTriggerTriggerStateDelegate), type.GetMethod("getAnalogTriggerTriggerState"));
+
+            GetAnalogTriggerOutput = (GetAnalogTriggerOutputDelegate)Delegate.CreateDelegate(typeof(GetAnalogTriggerOutputDelegate), type.GetMethod("getAnalogTriggerOutput"));
+
+            GetAnalogSampleRateIntHack = (GetAnalogSampleRateIntHackDelegate)Delegate.CreateDelegate(typeof(GetAnalogSampleRateIntHackDelegate), type.GetMethod("getAnalogSampleRateIntHack"));
+
+            GetAnalogVoltageIntHack = (GetAnalogVoltageIntHackDelegate)Delegate.CreateDelegate(typeof(GetAnalogVoltageIntHackDelegate), type.GetMethod("getAnalogVoltageIntHack"));
+
+            GetAnalogAverageVoltageIntHack = (GetAnalogAverageVoltageIntHackDelegate)Delegate.CreateDelegate(typeof(GetAnalogAverageVoltageIntHackDelegate), type.GetMethod("getAnalogAverageVoltageIntHack"));
+
+            SetAnalogSampleRateIntHack = (SetAnalogSampleRateIntHackDelegate)Delegate.CreateDelegate(typeof(SetAnalogSampleRateIntHackDelegate), type.GetMethod("setAnalogSampleRateIntHack"));
+
+            GetAnalogVoltsToValueIntHack = (GetAnalogVoltsToValueIntHackDelegate)Delegate.CreateDelegate(typeof(GetAnalogVoltsToValueIntHackDelegate), type.GetMethod("getAnalogVoltsToValueIntHack"));
+
+            SetAnalogTriggerLimitsVoltageIntHack = (SetAnalogTriggerLimitsVoltageIntHackDelegate)Delegate.CreateDelegate(typeof(SetAnalogTriggerLimitsVoltageIntHackDelegate), type.GetMethod("setAnalogTriggerLimitsVoltageIntHack"));
+        }
+
+        public delegate System.IntPtr InitializeAnalogOutputPortDelegate(System.IntPtr portPointer, ref int status);
+        public static InitializeAnalogOutputPortDelegate InitializeAnalogOutputPort;
+
+        public delegate void SetAnalogOutputDelegate(System.IntPtr analogPortPointer, double voltage, ref int status);
+        public static SetAnalogOutputDelegate SetAnalogOutput;
+
+        public delegate double GetAnalogOutputDelegate(System.IntPtr analogPortPointer, ref int status);
+        public static GetAnalogOutputDelegate GetAnalogOutput;
+
+        public delegate bool CheckAnalogOutputChannelDelegate(uint pin);
+        public static CheckAnalogOutputChannelDelegate CheckAnalogOutputChannel;
+
+        public delegate System.IntPtr InitializeAnalogInputPortDelegate(System.IntPtr portPointer, ref int status);
+        public static InitializeAnalogInputPortDelegate InitializeAnalogInputPort;
+
+        public delegate bool CheckAnalogModuleDelegate(byte module);
+        public static CheckAnalogModuleDelegate CheckAnalogModule;
+
+        public delegate bool CheckAnalogInputChannelDelegate(uint pin);
+        public static CheckAnalogInputChannelDelegate CheckAnalogInputChannel;
+
+        public delegate void SetAnalogSampleRateDelegate(double samplesPerSecond, ref int status);
+        public static SetAnalogSampleRateDelegate SetAnalogSampleRate;
+
+        public delegate float GetAnalogSampleRateDelegate(ref int status);
+        public static GetAnalogSampleRateDelegate GetAnalogSampleRate;
+
+        public delegate void SetAnalogAverageBitsDelegate(System.IntPtr analogPortPointer, uint bits, ref int status);
+        public static SetAnalogAverageBitsDelegate SetAnalogAverageBits;
+
+        public delegate uint GetAnalogAverageBitsDelegate(System.IntPtr analogPortPointer, ref int status);
+        public static GetAnalogAverageBitsDelegate GetAnalogAverageBits;
+
+        public delegate void SetAnalogOversampleBitsDelegate(System.IntPtr analogPortPointer, uint bits, ref int status);
+        public static SetAnalogOversampleBitsDelegate SetAnalogOversampleBits;
+
+        public delegate uint GetAnalogOversampleBitsDelegate(System.IntPtr analogPortPointer, ref int status);
+        public static GetAnalogOversampleBitsDelegate GetAnalogOversampleBits;
+
+        public delegate short GetAnalogValueDelegate(System.IntPtr analogPortPointer, ref int status);
+        public static GetAnalogValueDelegate GetAnalogValue;
+
+        public delegate int GetAnalogAverageValueDelegate(System.IntPtr analogPortPointer, ref int status);
+        public static GetAnalogAverageValueDelegate GetAnalogAverageValue;
+
+        public delegate int GetAnalogVoltsToValueDelegate(System.IntPtr analogPortPointer, double voltage, ref int status);
+        public static GetAnalogVoltsToValueDelegate GetAnalogVoltsToValue;
+
+        public delegate float GetAnalogVoltageDelegate(System.IntPtr analogPortPointer, ref int status);
+        public static GetAnalogVoltageDelegate GetAnalogVoltage;
+
+        public delegate float GetAnalogAverageVoltageDelegate(System.IntPtr analogPortPointer, ref int status);
+        public static GetAnalogAverageVoltageDelegate GetAnalogAverageVoltage;
+
+        public delegate uint GetAnalogLSBWeightDelegate(System.IntPtr analogPortPointer, ref int status);
+        public static GetAnalogLSBWeightDelegate GetAnalogLSBWeight;
+
+        public delegate int GetAnalogOffsetDelegate(System.IntPtr analogPortPointer, ref int status);
+        public static GetAnalogOffsetDelegate GetAnalogOffset;
+
+        public delegate bool IsAccumulatorChannelDelegate(System.IntPtr analogPortPointer, ref int status);
+        public static IsAccumulatorChannelDelegate IsAccumulatorChannel;
+
+        public delegate void InitAccumulatorDelegate(System.IntPtr analogPortPointer, ref int status);
+        public static InitAccumulatorDelegate InitAccumulator;
+
+        public delegate void ResetAccumulatorDelegate(System.IntPtr analogPortPointer, ref int status);
+        public static ResetAccumulatorDelegate ResetAccumulator;
+
+        public delegate void SetAccumulatorCenterDelegate(System.IntPtr analogPortPointer, int center, ref int status);
+        public static SetAccumulatorCenterDelegate SetAccumulatorCenter;
+
+        public delegate void SetAccumulatorDeadbandDelegate(System.IntPtr analogPortPointer, int deadband, ref int status);
+        public static SetAccumulatorDeadbandDelegate SetAccumulatorDeadband;
+
+        public delegate int GetAccumulatorValueDelegate(System.IntPtr analogPortPointer, ref int status);
+        public static GetAccumulatorValueDelegate GetAccumulatorValue;
+
+        public delegate uint GetAccumulatorCountDelegate(System.IntPtr analogPortPointer, ref int status);
+        public static GetAccumulatorCountDelegate GetAccumulatorCount;
+
+        public delegate void GetAccumulatorOutputDelegate(System.IntPtr analogPortPointer, ref int value, ref uint count, ref int status);
+        public static GetAccumulatorOutputDelegate GetAccumulatorOutput;
+
+        public delegate System.IntPtr InitializeAnalogTriggerDelegate(System.IntPtr portPointer, ref uint index, ref int status);
+        public static InitializeAnalogTriggerDelegate InitializeAnalogTrigger;
+
+        public delegate void CleanAnalogTriggerDelegate(System.IntPtr analogTriggerPointer, ref int status);
+        public static CleanAnalogTriggerDelegate CleanAnalogTrigger;
+
+        public delegate void SetAnalogTriggerLimitsRawDelegate(System.IntPtr analogTriggerPointer, int lower, int upper, ref int status);
+        public static SetAnalogTriggerLimitsRawDelegate SetAnalogTriggerLimitsRaw;
+
+        public delegate void SetAnalogTriggerLimitsVoltageDelegate(System.IntPtr analogTriggerPointer, double lower, double upper, ref int status);
+        public static SetAnalogTriggerLimitsVoltageDelegate SetAnalogTriggerLimitsVoltage;
+
+        public delegate void SetAnalogTriggerAveragedDelegate(System.IntPtr analogTriggerPointer, [System.Runtime.InteropServices.MarshalAsAttribute(System.Runtime.InteropServices.UnmanagedType.I1)] bool useAveragedValue, ref int status);
+        public static SetAnalogTriggerAveragedDelegate SetAnalogTriggerAveraged;
+
+        public delegate void SetAnalogTriggerFilteredDelegate(System.IntPtr analogTriggerPointer, [System.Runtime.InteropServices.MarshalAsAttribute(System.Runtime.InteropServices.UnmanagedType.I1)] bool useFilteredValue, ref int status);
+        public static SetAnalogTriggerFilteredDelegate SetAnalogTriggerFiltered;
+
+        public delegate bool GetAnalogTriggerInWindowDelegate(System.IntPtr analogTriggerPointer, ref int status);
+        public static GetAnalogTriggerInWindowDelegate GetAnalogTriggerInWindow;
+
+        public delegate bool GetAnalogTriggerTriggerStateDelegate(System.IntPtr analogTriggerPointer, ref int status);
+        public static GetAnalogTriggerTriggerStateDelegate GetAnalogTriggerTriggerState;
+
+        public delegate bool GetAnalogTriggerOutputDelegate(System.IntPtr analogTriggerPointer, AnalogTriggerType type, ref int status);
+        public static GetAnalogTriggerOutputDelegate GetAnalogTriggerOutput;
+
+        public delegate int GetAnalogSampleRateIntHackDelegate(ref int status);
+        public static GetAnalogSampleRateIntHackDelegate GetAnalogSampleRateIntHack;
+
+        public delegate int GetAnalogVoltageIntHackDelegate(System.IntPtr analogPortPointer, ref int status);
+        public static GetAnalogVoltageIntHackDelegate GetAnalogVoltageIntHack;
+
+        public delegate int GetAnalogAverageVoltageIntHackDelegate(System.IntPtr analogPortPointer, ref int status);
+        public static GetAnalogAverageVoltageIntHackDelegate GetAnalogAverageVoltageIntHack;
+
+        public delegate void SetAnalogSampleRateIntHackDelegate(int samplesPerSecond, ref int status);
+        public static SetAnalogSampleRateIntHackDelegate SetAnalogSampleRateIntHack;
+
+        public delegate int GetAnalogVoltsToValueIntHackDelegate(System.IntPtr analogPortPointer, int voltage, ref int status);
+        public static GetAnalogVoltsToValueIntHackDelegate GetAnalogVoltsToValueIntHack;
+
+        public delegate void SetAnalogTriggerLimitsVoltageIntHackDelegate(System.IntPtr analogTriggerPointer, int lower, int upper, ref int status);
+        public static SetAnalogTriggerLimitsVoltageIntHackDelegate SetAnalogTriggerLimitsVoltageIntHack;
+    }
+}

--- a/HAL-Base/HALCANTalon.cs
+++ b/HAL-Base/HALCANTalon.cs
@@ -1,0 +1,310 @@
+﻿
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace HAL_Base
+{
+    public enum CTR_Code
+    {
+        CTR_OKAY,
+
+        CTR_RxTimeout,
+
+        CTR_TxTimeout,
+
+        CTR_InvalidParamValue,
+
+        CTR_UnexpectedArbId,
+
+        CTR_TxFailed,
+
+        CTR_SigNotUpdated,
+    }
+    public class HALCANTalon
+    {
+        internal static void SetupDelegate()
+        {
+            string className = MethodBase.GetCurrentMethod().DeclaringType.Name;
+            var types = HAL.HALAssembly.GetTypes();
+            var q = from t in types where t.IsClass && t.Name == className select t;
+
+            Type type = HAL.HALAssembly.GetType(q.ToList()[0].FullName);
+
+            C_TalonSRX_Create = (C_TalonSRX_CreateDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_CreateDelegate), type.GetMethod("c_TalonSRX_Create"));
+
+            C_TalonSRX_Destroy = (C_TalonSRX_DestroyDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_DestroyDelegate), type.GetMethod("c_TalonSRX_Destroy"));
+
+            C_TalonSRX_SetParam = (C_TalonSRX_SetParamDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_SetParamDelegate), type.GetMethod("c_TalonSRX_SetParam"));
+
+            C_TalonSRX_RequestParam = (C_TalonSRX_RequestParamDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_RequestParamDelegate), type.GetMethod("c_TalonSRX_RequestParam"));
+
+            C_TalonSRX_GetParamResponse = (C_TalonSRX_GetParamResponseDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_GetParamResponseDelegate), type.GetMethod("c_TalonSRX_GetParamResponse"));
+
+            C_TalonSRX_GetParamResponseInt32 = (C_TalonSRX_GetParamResponseInt32Delegate)Delegate.CreateDelegate(typeof(C_TalonSRX_GetParamResponseInt32Delegate), type.GetMethod("c_TalonSRX_GetParamResponseInt32"));
+
+            C_TalonSRX_SetStatusFrameRate = (C_TalonSRX_SetStatusFrameRateDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_SetStatusFrameRateDelegate), type.GetMethod("c_TalonSRX_SetStatusFrameRate"));
+
+            C_TalonSRX_ClearStickyFaults = (C_TalonSRX_ClearStickyFaultsDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_ClearStickyFaultsDelegate), type.GetMethod("c_TalonSRX_ClearStickyFaults"));
+
+            C_TalonSRX_GetFault_OverTemp = (C_TalonSRX_GetFault_OverTempDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_GetFault_OverTempDelegate), type.GetMethod("c_TalonSRX_GetFault_OverTemp"));
+
+            C_TalonSRX_GetFault_UnderVoltage = (C_TalonSRX_GetFault_UnderVoltageDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_GetFault_UnderVoltageDelegate), type.GetMethod("c_TalonSRX_GetFault_UnderVoltage"));
+
+            C_TalonSRX_GetFault_ForLim = (C_TalonSRX_GetFault_ForLimDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_GetFault_ForLimDelegate), type.GetMethod("c_TalonSRX_GetFault_ForLim"));
+
+            C_TalonSRX_GetFault_RevLim = (C_TalonSRX_GetFault_RevLimDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_GetFault_RevLimDelegate), type.GetMethod("c_TalonSRX_GetFault_RevLim"));
+
+            C_TalonSRX_GetFault_HardwareFailure = (C_TalonSRX_GetFault_HardwareFailureDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_GetFault_HardwareFailureDelegate), type.GetMethod("c_TalonSRX_GetFault_HardwareFailure"));
+
+            C_TalonSRX_GetFault_ForSoftLim = (C_TalonSRX_GetFault_ForSoftLimDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_GetFault_ForSoftLimDelegate), type.GetMethod("c_TalonSRX_GetFault_ForSoftLim"));
+
+            C_TalonSRX_GetFault_RevSoftLim = (C_TalonSRX_GetFault_RevSoftLimDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_GetFault_RevSoftLimDelegate), type.GetMethod("c_TalonSRX_GetFault_RevSoftLim"));
+
+            C_TalonSRX_GetStckyFault_OverTemp = (C_TalonSRX_GetStckyFault_OverTempDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_GetStckyFault_OverTempDelegate), type.GetMethod("c_TalonSRX_GetStckyFault_OverTemp"));
+
+            C_TalonSRX_GetStckyFault_UnderVoltage = (C_TalonSRX_GetStckyFault_UnderVoltageDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_GetStckyFault_UnderVoltageDelegate), type.GetMethod("c_TalonSRX_GetStckyFault_UnderVoltage"));
+
+            C_TalonSRX_GetStckyFault_ForLim = (C_TalonSRX_GetStckyFault_ForLimDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_GetStckyFault_ForLimDelegate), type.GetMethod("c_TalonSRX_GetStckyFault_ForLim"));
+
+            C_TalonSRX_GetStckyFault_RevLim = (C_TalonSRX_GetStckyFault_RevLimDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_GetStckyFault_RevLimDelegate), type.GetMethod("c_TalonSRX_GetStckyFault_RevLim"));
+
+            C_TalonSRX_GetStckyFault_ForSoftLim = (C_TalonSRX_GetStckyFault_ForSoftLimDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_GetStckyFault_ForSoftLimDelegate), type.GetMethod("c_TalonSRX_GetStckyFault_ForSoftLim"));
+
+            C_TalonSRX_GetStckyFault_RevSoftLim = (C_TalonSRX_GetStckyFault_RevSoftLimDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_GetStckyFault_RevSoftLimDelegate), type.GetMethod("c_TalonSRX_GetStckyFault_RevSoftLim"));
+
+            C_TalonSRX_GetAppliedThrottle = (C_TalonSRX_GetAppliedThrottleDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_GetAppliedThrottleDelegate), type.GetMethod("c_TalonSRX_GetAppliedThrottle"));
+
+            C_TalonSRX_GetCloseLoopErr = (C_TalonSRX_GetCloseLoopErrDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_GetCloseLoopErrDelegate), type.GetMethod("c_TalonSRX_GetCloseLoopErr"));
+
+            C_TalonSRX_GetFeedbackDeviceSelect = (C_TalonSRX_GetFeedbackDeviceSelectDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_GetFeedbackDeviceSelectDelegate), type.GetMethod("c_TalonSRX_GetFeedbackDeviceSelect"));
+
+            C_TalonSRX_GetModeSelect = (C_TalonSRX_GetModeSelectDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_GetModeSelectDelegate), type.GetMethod("c_TalonSRX_GetModeSelect"));
+
+            C_TalonSRX_GetLimitSwitchEn = (C_TalonSRX_GetLimitSwitchEnDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_GetLimitSwitchEnDelegate), type.GetMethod("c_TalonSRX_GetLimitSwitchEn"));
+
+            C_TalonSRX_GetLimitSwitchClosedFor = (C_TalonSRX_GetLimitSwitchClosedForDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_GetLimitSwitchClosedForDelegate), type.GetMethod("c_TalonSRX_GetLimitSwitchClosedFor"));
+
+            C_TalonSRX_GetLimitSwitchClosedRev = (C_TalonSRX_GetLimitSwitchClosedRevDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_GetLimitSwitchClosedRevDelegate), type.GetMethod("c_TalonSRX_GetLimitSwitchClosedRev"));
+
+            C_TalonSRX_GetSensorPosition = (C_TalonSRX_GetSensorPositionDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_GetSensorPositionDelegate), type.GetMethod("c_TalonSRX_GetSensorPosition"));
+
+            C_TalonSRX_GetSensorVelocity = (C_TalonSRX_GetSensorVelocityDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_GetSensorVelocityDelegate), type.GetMethod("c_TalonSRX_GetSensorVelocity"));
+
+            C_TalonSRX_GetCurrent = (C_TalonSRX_GetCurrentDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_GetCurrentDelegate), type.GetMethod("c_TalonSRX_GetCurrent"));
+
+            C_TalonSRX_GetBrakeIsEnabled = (C_TalonSRX_GetBrakeIsEnabledDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_GetBrakeIsEnabledDelegate), type.GetMethod("c_TalonSRX_GetBrakeIsEnabled"));
+
+            C_TalonSRX_GetEncPosition = (C_TalonSRX_GetEncPositionDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_GetEncPositionDelegate), type.GetMethod("c_TalonSRX_GetEncPosition"));
+
+            C_TalonSRX_GetEncVel = (C_TalonSRX_GetEncVelDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_GetEncVelDelegate), type.GetMethod("c_TalonSRX_GetEncVel"));
+
+            C_TalonSRX_GetEncIndexRiseEvents = (C_TalonSRX_GetEncIndexRiseEventsDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_GetEncIndexRiseEventsDelegate), type.GetMethod("c_TalonSRX_GetEncIndexRiseEvents"));
+
+            C_TalonSRX_GetQuadApin = (C_TalonSRX_GetQuadApinDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_GetQuadApinDelegate), type.GetMethod("c_TalonSRX_GetQuadApin"));
+
+            C_TalonSRX_GetQuadBpin = (C_TalonSRX_GetQuadBpinDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_GetQuadBpinDelegate), type.GetMethod("c_TalonSRX_GetQuadBpin"));
+
+            C_TalonSRX_GetQuadIdxpin = (C_TalonSRX_GetQuadIdxpinDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_GetQuadIdxpinDelegate), type.GetMethod("c_TalonSRX_GetQuadIdxpin"));
+
+            C_TalonSRX_GetAnalogInWithOv = (C_TalonSRX_GetAnalogInWithOvDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_GetAnalogInWithOvDelegate), type.GetMethod("c_TalonSRX_GetAnalogInWithOv"));
+
+            C_TalonSRX_GetAnalogInVel = (C_TalonSRX_GetAnalogInVelDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_GetAnalogInVelDelegate), type.GetMethod("c_TalonSRX_GetAnalogInVel"));
+
+            C_TalonSRX_GetTemp = (C_TalonSRX_GetTempDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_GetTempDelegate), type.GetMethod("c_TalonSRX_GetTemp"));
+
+            C_TalonSRX_GetBatteryV = (C_TalonSRX_GetBatteryVDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_GetBatteryVDelegate), type.GetMethod("c_TalonSRX_GetBatteryV"));
+
+            C_TalonSRX_GetResetCount = (C_TalonSRX_GetResetCountDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_GetResetCountDelegate), type.GetMethod("c_TalonSRX_GetResetCount"));
+
+            C_TalonSRX_GetResetFlags = (C_TalonSRX_GetResetFlagsDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_GetResetFlagsDelegate), type.GetMethod("c_TalonSRX_GetResetFlags"));
+
+            C_TalonSRX_GetFirmVers = (C_TalonSRX_GetFirmVersDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_GetFirmVersDelegate), type.GetMethod("c_TalonSRX_GetFirmVers"));
+
+            C_TalonSRX_SetDemand = (C_TalonSRX_SetDemandDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_SetDemandDelegate), type.GetMethod("c_TalonSRX_SetDemand"));
+
+            C_TalonSRX_SetOverrideLimitSwitchEn = (C_TalonSRX_SetOverrideLimitSwitchEnDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_SetOverrideLimitSwitchEnDelegate), type.GetMethod("c_TalonSRX_SetOverrideLimitSwitchEn"));
+
+            C_TalonSRX_SetFeedbackDeviceSelect = (C_TalonSRX_SetFeedbackDeviceSelectDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_SetFeedbackDeviceSelectDelegate), type.GetMethod("c_TalonSRX_SetFeedbackDeviceSelect"));
+
+            C_TalonSRX_SetRevMotDuringCloseLoopEn = (C_TalonSRX_SetRevMotDuringCloseLoopEnDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_SetRevMotDuringCloseLoopEnDelegate), type.GetMethod("c_TalonSRX_SetRevMotDuringCloseLoopEn"));
+
+            C_TalonSRX_SetOverrideBrakeType = (C_TalonSRX_SetOverrideBrakeTypeDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_SetOverrideBrakeTypeDelegate), type.GetMethod("c_TalonSRX_SetOverrideBrakeType"));
+
+            C_TalonSRX_SetModeSelect = (C_TalonSRX_SetModeSelectDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_SetModeSelectDelegate), type.GetMethod("c_TalonSRX_SetModeSelect"));
+
+            C_TalonSRX_SetModeSelect2 = (C_TalonSRX_SetModeSelect2Delegate)Delegate.CreateDelegate(typeof(C_TalonSRX_SetModeSelect2Delegate), type.GetMethod("c_TalonSRX_SetModeSelect2"));
+
+            C_TalonSRX_SetProfileSlotSelect = (C_TalonSRX_SetProfileSlotSelectDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_SetProfileSlotSelectDelegate), type.GetMethod("c_TalonSRX_SetProfileSlotSelect"));
+
+            C_TalonSRX_SetRampThrottle = (C_TalonSRX_SetRampThrottleDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_SetRampThrottleDelegate), type.GetMethod("c_TalonSRX_SetRampThrottle"));
+
+            C_TalonSRX_SetRevFeedbackSensor = (C_TalonSRX_SetRevFeedbackSensorDelegate)Delegate.CreateDelegate(typeof(C_TalonSRX_SetRevFeedbackSensorDelegate), type.GetMethod("c_TalonSRX_SetRevFeedbackSensor"));
+        }
+
+        public delegate System.IntPtr C_TalonSRX_CreateDelegate(int deviceNumber, int controlPeriodMs);
+        public static C_TalonSRX_CreateDelegate C_TalonSRX_Create;
+
+        public delegate void C_TalonSRX_DestroyDelegate(System.IntPtr handle);
+        public static C_TalonSRX_DestroyDelegate C_TalonSRX_Destroy;
+
+        public delegate CTR_Code C_TalonSRX_SetParamDelegate(System.IntPtr handle, int paramEnum, double value);
+        public static C_TalonSRX_SetParamDelegate C_TalonSRX_SetParam;
+
+        public delegate CTR_Code C_TalonSRX_RequestParamDelegate(System.IntPtr handle, int paramEnum);
+        public static C_TalonSRX_RequestParamDelegate C_TalonSRX_RequestParam;
+
+        public delegate CTR_Code C_TalonSRX_GetParamResponseDelegate(System.IntPtr handle, int paramEnum, ref double value);
+        public static C_TalonSRX_GetParamResponseDelegate C_TalonSRX_GetParamResponse;
+
+        public delegate CTR_Code C_TalonSRX_GetParamResponseInt32Delegate(System.IntPtr handle, int paramEnum, ref int value);
+        public static C_TalonSRX_GetParamResponseInt32Delegate C_TalonSRX_GetParamResponseInt32;
+
+        public delegate CTR_Code C_TalonSRX_SetStatusFrameRateDelegate(System.IntPtr handle, uint frameEnum, uint periodMs);
+        public static C_TalonSRX_SetStatusFrameRateDelegate C_TalonSRX_SetStatusFrameRate;
+
+        public delegate CTR_Code C_TalonSRX_ClearStickyFaultsDelegate(System.IntPtr handle);
+        public static C_TalonSRX_ClearStickyFaultsDelegate C_TalonSRX_ClearStickyFaults;
+
+        public delegate CTR_Code C_TalonSRX_GetFault_OverTempDelegate(System.IntPtr handle, ref int param);
+        public static C_TalonSRX_GetFault_OverTempDelegate C_TalonSRX_GetFault_OverTemp;
+
+        public delegate CTR_Code C_TalonSRX_GetFault_UnderVoltageDelegate(System.IntPtr handle, ref int param);
+        public static C_TalonSRX_GetFault_UnderVoltageDelegate C_TalonSRX_GetFault_UnderVoltage;
+
+        public delegate CTR_Code C_TalonSRX_GetFault_ForLimDelegate(System.IntPtr handle, ref int param);
+        public static C_TalonSRX_GetFault_ForLimDelegate C_TalonSRX_GetFault_ForLim;
+
+        public delegate CTR_Code C_TalonSRX_GetFault_RevLimDelegate(System.IntPtr handle, ref int param);
+        public static C_TalonSRX_GetFault_RevLimDelegate C_TalonSRX_GetFault_RevLim;
+
+        public delegate CTR_Code C_TalonSRX_GetFault_HardwareFailureDelegate(System.IntPtr handle, ref int param);
+        public static C_TalonSRX_GetFault_HardwareFailureDelegate C_TalonSRX_GetFault_HardwareFailure;
+
+        public delegate CTR_Code C_TalonSRX_GetFault_ForSoftLimDelegate(System.IntPtr handle, ref int param);
+        public static C_TalonSRX_GetFault_ForSoftLimDelegate C_TalonSRX_GetFault_ForSoftLim;
+
+        public delegate CTR_Code C_TalonSRX_GetFault_RevSoftLimDelegate(System.IntPtr handle, ref int param);
+        public static C_TalonSRX_GetFault_RevSoftLimDelegate C_TalonSRX_GetFault_RevSoftLim;
+
+        public delegate CTR_Code C_TalonSRX_GetStckyFault_OverTempDelegate(System.IntPtr handle, ref int param);
+        public static C_TalonSRX_GetStckyFault_OverTempDelegate C_TalonSRX_GetStckyFault_OverTemp;
+
+        public delegate CTR_Code C_TalonSRX_GetStckyFault_UnderVoltageDelegate(System.IntPtr handle, ref int param);
+        public static C_TalonSRX_GetStckyFault_UnderVoltageDelegate C_TalonSRX_GetStckyFault_UnderVoltage;
+
+        public delegate CTR_Code C_TalonSRX_GetStckyFault_ForLimDelegate(System.IntPtr handle, ref int param);
+        public static C_TalonSRX_GetStckyFault_ForLimDelegate C_TalonSRX_GetStckyFault_ForLim;
+
+        public delegate CTR_Code C_TalonSRX_GetStckyFault_RevLimDelegate(System.IntPtr handle, ref int param);
+        public static C_TalonSRX_GetStckyFault_RevLimDelegate C_TalonSRX_GetStckyFault_RevLim;
+
+        public delegate CTR_Code C_TalonSRX_GetStckyFault_ForSoftLimDelegate(System.IntPtr handle, ref int param);
+        public static C_TalonSRX_GetStckyFault_ForSoftLimDelegate C_TalonSRX_GetStckyFault_ForSoftLim;
+
+        public delegate CTR_Code C_TalonSRX_GetStckyFault_RevSoftLimDelegate(System.IntPtr handle, ref int param);
+        public static C_TalonSRX_GetStckyFault_RevSoftLimDelegate C_TalonSRX_GetStckyFault_RevSoftLim;
+
+        public delegate CTR_Code C_TalonSRX_GetAppliedThrottleDelegate(System.IntPtr handle, ref int param);
+        public static C_TalonSRX_GetAppliedThrottleDelegate C_TalonSRX_GetAppliedThrottle;
+
+        public delegate CTR_Code C_TalonSRX_GetCloseLoopErrDelegate(System.IntPtr handle, ref int param);
+        public static C_TalonSRX_GetCloseLoopErrDelegate C_TalonSRX_GetCloseLoopErr;
+
+        public delegate CTR_Code C_TalonSRX_GetFeedbackDeviceSelectDelegate(System.IntPtr handle, ref int param);
+        public static C_TalonSRX_GetFeedbackDeviceSelectDelegate C_TalonSRX_GetFeedbackDeviceSelect;
+
+        public delegate CTR_Code C_TalonSRX_GetModeSelectDelegate(System.IntPtr handle, ref int param);
+        public static C_TalonSRX_GetModeSelectDelegate C_TalonSRX_GetModeSelect;
+
+        public delegate CTR_Code C_TalonSRX_GetLimitSwitchEnDelegate(System.IntPtr handle, ref int param);
+        public static C_TalonSRX_GetLimitSwitchEnDelegate C_TalonSRX_GetLimitSwitchEn;
+
+        public delegate CTR_Code C_TalonSRX_GetLimitSwitchClosedForDelegate(System.IntPtr handle, ref int param);
+        public static C_TalonSRX_GetLimitSwitchClosedForDelegate C_TalonSRX_GetLimitSwitchClosedFor;
+
+        public delegate CTR_Code C_TalonSRX_GetLimitSwitchClosedRevDelegate(System.IntPtr handle, ref int param);
+        public static C_TalonSRX_GetLimitSwitchClosedRevDelegate C_TalonSRX_GetLimitSwitchClosedRev;
+
+        public delegate CTR_Code C_TalonSRX_GetSensorPositionDelegate(System.IntPtr handle, ref int param);
+        public static C_TalonSRX_GetSensorPositionDelegate C_TalonSRX_GetSensorPosition;
+
+        public delegate CTR_Code C_TalonSRX_GetSensorVelocityDelegate(System.IntPtr handle, ref int param);
+        public static C_TalonSRX_GetSensorVelocityDelegate C_TalonSRX_GetSensorVelocity;
+
+        public delegate CTR_Code C_TalonSRX_GetCurrentDelegate(System.IntPtr handle, ref double param);
+        public static C_TalonSRX_GetCurrentDelegate C_TalonSRX_GetCurrent;
+
+        public delegate CTR_Code C_TalonSRX_GetBrakeIsEnabledDelegate(System.IntPtr handle, ref int param);
+        public static C_TalonSRX_GetBrakeIsEnabledDelegate C_TalonSRX_GetBrakeIsEnabled;
+
+        public delegate CTR_Code C_TalonSRX_GetEncPositionDelegate(System.IntPtr handle, ref int param);
+        public static C_TalonSRX_GetEncPositionDelegate C_TalonSRX_GetEncPosition;
+
+        public delegate CTR_Code C_TalonSRX_GetEncVelDelegate(System.IntPtr handle, ref int param);
+        public static C_TalonSRX_GetEncVelDelegate C_TalonSRX_GetEncVel;
+
+        public delegate CTR_Code C_TalonSRX_GetEncIndexRiseEventsDelegate(System.IntPtr handle, ref int param);
+        public static C_TalonSRX_GetEncIndexRiseEventsDelegate C_TalonSRX_GetEncIndexRiseEvents;
+
+        public delegate CTR_Code C_TalonSRX_GetQuadApinDelegate(System.IntPtr handle, ref int param);
+        public static C_TalonSRX_GetQuadApinDelegate C_TalonSRX_GetQuadApin;
+
+        public delegate CTR_Code C_TalonSRX_GetQuadBpinDelegate(System.IntPtr handle, ref int param);
+        public static C_TalonSRX_GetQuadBpinDelegate C_TalonSRX_GetQuadBpin;
+
+        public delegate CTR_Code C_TalonSRX_GetQuadIdxpinDelegate(System.IntPtr handle, ref int param);
+        public static C_TalonSRX_GetQuadIdxpinDelegate C_TalonSRX_GetQuadIdxpin;
+
+        public delegate CTR_Code C_TalonSRX_GetAnalogInWithOvDelegate(System.IntPtr handle, ref int param);
+        public static C_TalonSRX_GetAnalogInWithOvDelegate C_TalonSRX_GetAnalogInWithOv;
+
+        public delegate CTR_Code C_TalonSRX_GetAnalogInVelDelegate(System.IntPtr handle, ref int param);
+        public static C_TalonSRX_GetAnalogInVelDelegate C_TalonSRX_GetAnalogInVel;
+
+        public delegate CTR_Code C_TalonSRX_GetTempDelegate(System.IntPtr handle, ref double param);
+        public static C_TalonSRX_GetTempDelegate C_TalonSRX_GetTemp;
+
+        public delegate CTR_Code C_TalonSRX_GetBatteryVDelegate(System.IntPtr handle, ref double param);
+        public static C_TalonSRX_GetBatteryVDelegate C_TalonSRX_GetBatteryV;
+
+        public delegate CTR_Code C_TalonSRX_GetResetCountDelegate(System.IntPtr handle, ref int param);
+        public static C_TalonSRX_GetResetCountDelegate C_TalonSRX_GetResetCount;
+
+        public delegate CTR_Code C_TalonSRX_GetResetFlagsDelegate(System.IntPtr handle, ref int param);
+        public static C_TalonSRX_GetResetFlagsDelegate C_TalonSRX_GetResetFlags;
+
+        public delegate CTR_Code C_TalonSRX_GetFirmVersDelegate(System.IntPtr handle, ref int param);
+        public static C_TalonSRX_GetFirmVersDelegate C_TalonSRX_GetFirmVers;
+
+        public delegate CTR_Code C_TalonSRX_SetDemandDelegate(System.IntPtr handle, int param);
+        public static C_TalonSRX_SetDemandDelegate C_TalonSRX_SetDemand;
+
+        public delegate CTR_Code C_TalonSRX_SetOverrideLimitSwitchEnDelegate(System.IntPtr handle, int param);
+        public static C_TalonSRX_SetOverrideLimitSwitchEnDelegate C_TalonSRX_SetOverrideLimitSwitchEn;
+
+        public delegate CTR_Code C_TalonSRX_SetFeedbackDeviceSelectDelegate(System.IntPtr handle, int param);
+        public static C_TalonSRX_SetFeedbackDeviceSelectDelegate C_TalonSRX_SetFeedbackDeviceSelect;
+
+        public delegate CTR_Code C_TalonSRX_SetRevMotDuringCloseLoopEnDelegate(System.IntPtr handle, int param);
+        public static C_TalonSRX_SetRevMotDuringCloseLoopEnDelegate C_TalonSRX_SetRevMotDuringCloseLoopEn;
+
+        public delegate CTR_Code C_TalonSRX_SetOverrideBrakeTypeDelegate(System.IntPtr handle, int param);
+        public static C_TalonSRX_SetOverrideBrakeTypeDelegate C_TalonSRX_SetOverrideBrakeType;
+
+        public delegate CTR_Code C_TalonSRX_SetModeSelectDelegate(System.IntPtr handle, int param);
+        public static C_TalonSRX_SetModeSelectDelegate C_TalonSRX_SetModeSelect;
+
+        public delegate CTR_Code C_TalonSRX_SetModeSelect2Delegate(System.IntPtr handle, int modeSelect, int demand);
+        public static C_TalonSRX_SetModeSelect2Delegate C_TalonSRX_SetModeSelect2;
+
+        public delegate CTR_Code C_TalonSRX_SetProfileSlotSelectDelegate(System.IntPtr handle, int param);
+        public static C_TalonSRX_SetProfileSlotSelectDelegate C_TalonSRX_SetProfileSlotSelect;
+
+        public delegate CTR_Code C_TalonSRX_SetRampThrottleDelegate(System.IntPtr handle, int param);
+        public static C_TalonSRX_SetRampThrottleDelegate C_TalonSRX_SetRampThrottle;
+
+        public delegate CTR_Code C_TalonSRX_SetRevFeedbackSensorDelegate(System.IntPtr handle, int param);
+        public static C_TalonSRX_SetRevFeedbackSensorDelegate C_TalonSRX_SetRevFeedbackSensor;
+    }
+}

--- a/HAL-Base/HALCompressor.cs
+++ b/HAL-Base/HALCompressor.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+
+namespace HAL_Base
+{
+    public class HALCompressor
+    {
+        internal static void SetupDelegate()
+        {
+            string className = MethodBase.GetCurrentMethod().DeclaringType.Name;
+            var types = HAL.HALAssembly.GetTypes();
+            var q = from t in types where t.IsClass && t.Name == className select t;
+
+            Type type = HAL.HALAssembly.GetType(q.ToList()[0].FullName);
+
+            InitializeCompressor = (InitializeCompressorDelegate)Delegate.CreateDelegate(typeof(InitializeCompressorDelegate), type.GetMethod("initializeCompressor"));
+
+            CheckCompressorModule = (CheckCompressorModuleDelegate)Delegate.CreateDelegate(typeof(CheckCompressorModuleDelegate), type.GetMethod("checkCompressorModule"));
+
+            GetCompressor = (GetCompressorDelegate)Delegate.CreateDelegate(typeof(GetCompressorDelegate), type.GetMethod("getCompressor"));
+
+            SetClosedLoopControl = (SetClosedLoopControlDelegate)Delegate.CreateDelegate(typeof(SetClosedLoopControlDelegate), type.GetMethod("setClosedLoopControl"));
+
+            GetClosedLoopControl = (GetClosedLoopControlDelegate)Delegate.CreateDelegate(typeof(GetClosedLoopControlDelegate), type.GetMethod("getClosedLoopControl"));
+
+            GetPressureSwitch = (GetPressureSwitchDelegate)Delegate.CreateDelegate(typeof(GetPressureSwitchDelegate), type.GetMethod("getPressureSwitch"));
+
+            GetCompressorCurrent = (GetCompressorCurrentDelegate)Delegate.CreateDelegate(typeof(GetCompressorCurrentDelegate), type.GetMethod("getCompressorCurrent"));
+
+            GetCompressorCurrentTooHighFault = (GetCompressorCurrentTooHighFaultDelegate)Delegate.CreateDelegate(typeof(GetCompressorCurrentTooHighFaultDelegate), type.GetMethod("getCompressorCurrentTooHighFault"));
+
+            GetCompressorCurrentTooHighStickyFault = (GetCompressorCurrentTooHighStickyFaultDelegate)Delegate.CreateDelegate(typeof(GetCompressorCurrentTooHighStickyFaultDelegate), type.GetMethod("getCompressorCurrentTooHighStickyFault"));
+
+            GetCompressorShortedStickyFault = (GetCompressorShortedStickyFaultDelegate)Delegate.CreateDelegate(typeof(GetCompressorShortedStickyFaultDelegate), type.GetMethod("getCompressorShortedStickyFault"));
+
+            GetCompressorShortedFault = (GetCompressorShortedFaultDelegate)Delegate.CreateDelegate(typeof(GetCompressorShortedFaultDelegate), type.GetMethod("getCompressorShortedFault"));
+
+            GetCompressorNotConnectedStickyFault = (GetCompressorNotConnectedStickyFaultDelegate)Delegate.CreateDelegate(typeof(GetCompressorNotConnectedStickyFaultDelegate), type.GetMethod("getCompressorNotConnectedStickyFault"));
+
+            GetCompressorNotConnectedFault = (GetCompressorNotConnectedFaultDelegate)Delegate.CreateDelegate(typeof(GetCompressorNotConnectedFaultDelegate), type.GetMethod("getCompressorNotConnectedFault"));
+
+            ClearAllPCMStickyFaults = (ClearAllPCMStickyFaultsDelegate)Delegate.CreateDelegate(typeof(ClearAllPCMStickyFaultsDelegate), type.GetMethod("clearAllPCMStickyFaults"));
+        }
+
+        public delegate System.IntPtr InitializeCompressorDelegate(byte module);
+        public static InitializeCompressorDelegate InitializeCompressor;
+
+        public delegate bool CheckCompressorModuleDelegate(byte module);
+        public static CheckCompressorModuleDelegate CheckCompressorModule;
+
+        public delegate bool GetCompressorDelegate(System.IntPtr pcmPointer, ref int status);
+        public static GetCompressorDelegate GetCompressor;
+
+        public delegate void SetClosedLoopControlDelegate(System.IntPtr pcmPointer, [System.Runtime.InteropServices.MarshalAsAttribute(System.Runtime.InteropServices.UnmanagedType.I1)] bool value, ref int status);
+        public static SetClosedLoopControlDelegate SetClosedLoopControl;
+
+        public delegate bool GetClosedLoopControlDelegate(System.IntPtr pcmPointer, ref int status);
+        public static GetClosedLoopControlDelegate GetClosedLoopControl;
+
+        public delegate bool GetPressureSwitchDelegate(System.IntPtr pcmPointer, ref int status);
+        public static GetPressureSwitchDelegate GetPressureSwitch;
+
+        public delegate float GetCompressorCurrentDelegate(System.IntPtr pcmPointer, ref int status);
+        public static GetCompressorCurrentDelegate GetCompressorCurrent;
+
+        public delegate bool GetCompressorCurrentTooHighFaultDelegate(System.IntPtr pcmPointer, ref int status);
+        public static GetCompressorCurrentTooHighFaultDelegate GetCompressorCurrentTooHighFault;
+
+        public delegate bool GetCompressorCurrentTooHighStickyFaultDelegate(System.IntPtr pcmPointer, ref int status);
+        public static GetCompressorCurrentTooHighStickyFaultDelegate GetCompressorCurrentTooHighStickyFault;
+
+        public delegate bool GetCompressorShortedStickyFaultDelegate(System.IntPtr pcmPointer, ref int status);
+        public static GetCompressorShortedStickyFaultDelegate GetCompressorShortedStickyFault;
+
+        public delegate bool GetCompressorShortedFaultDelegate(System.IntPtr pcmPointer, ref int status);
+        public static GetCompressorShortedFaultDelegate GetCompressorShortedFault;
+
+        public delegate bool GetCompressorNotConnectedStickyFaultDelegate(System.IntPtr pcmPointer, ref int status);
+        public static GetCompressorNotConnectedStickyFaultDelegate GetCompressorNotConnectedStickyFault;
+
+        public delegate bool GetCompressorNotConnectedFaultDelegate(System.IntPtr pcmPointer, ref int status);
+        public static GetCompressorNotConnectedFaultDelegate GetCompressorNotConnectedFault;
+
+        public delegate void ClearAllPCMStickyFaultsDelegate(System.IntPtr pcmPointer, ref int status);
+        public static ClearAllPCMStickyFaultsDelegate ClearAllPCMStickyFaults;
+    }
+}

--- a/HAL-Base/HALDigital.cs
+++ b/HAL-Base/HALDigital.cs
@@ -1,0 +1,449 @@
+﻿using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System;
+
+namespace HAL_Base
+{
+    public enum Mode
+    {
+        /// kTwoPulse -> 0
+        TwoPulse = 0,
+
+        /// kSemiperiod -> 1
+        Semiperiod = 1,
+
+        /// kPulseLength -> 2
+        PulseLength = 2,
+
+        /// kExternalDirection -> 3
+        ExternalDirection = 3,
+    }
+
+    public class HALDigital
+    {
+        internal static void SetupDelegates()
+        {
+            string className = MethodBase.GetCurrentMethod().DeclaringType.Name;
+            var types = HAL.HALAssembly.GetTypes();
+            var q = from t in types where t.IsClass && t.Name == className select t;
+
+            Type type = HAL.HALAssembly.GetType(q.ToList()[0].FullName);
+
+            InitializeDigitalPort = (InitializeDigitalPortDelegate)Delegate.CreateDelegate(typeof(InitializeDigitalPortDelegate), type.GetMethod("initializeDigitalPort"));
+
+            CheckPWMChannel = (CheckPWMChannelDelegate)Delegate.CreateDelegate(typeof(CheckPWMChannelDelegate), type.GetMethod("checkPWMChannel"));
+
+            CheckRelayChannel = (CheckRelayChannelDelegate)Delegate.CreateDelegate(typeof(CheckRelayChannelDelegate), type.GetMethod("checkRelayChannel"));
+
+            SetPWM = (SetPWMDelegate)Delegate.CreateDelegate(typeof(SetPWMDelegate), type.GetMethod("setPWM"));
+
+            AllocatePWMChannel = (AllocatePWMChannelDelegate)Delegate.CreateDelegate(typeof(AllocatePWMChannelDelegate), type.GetMethod("allocatePWMChannel"));
+
+            FreePWMChannel = (FreePWMChannelDelegate)Delegate.CreateDelegate(typeof(FreePWMChannelDelegate), type.GetMethod("freePWMChannel"));
+
+            GetPWM = (GetPWMDelegate)Delegate.CreateDelegate(typeof(GetPWMDelegate), type.GetMethod("getPWM"));
+
+            LatchPWMZero = (LatchPWMZeroDelegate)Delegate.CreateDelegate(typeof(LatchPWMZeroDelegate), type.GetMethod("latchPWMZero"));
+
+            SetPWMPeriodScale = (SetPWMPeriodScaleDelegate)Delegate.CreateDelegate(typeof(SetPWMPeriodScaleDelegate), type.GetMethod("setPWMPeriodScale"));
+
+            AllocatePWM = (AllocatePWMDelegate)Delegate.CreateDelegate(typeof(AllocatePWMDelegate), type.GetMethod("allocatePWM"));
+
+            FreePWM = (FreePWMDelegate)Delegate.CreateDelegate(typeof(FreePWMDelegate), type.GetMethod("freePWM"));
+
+            SetPWMRate = (SetPWMRateDelegate)Delegate.CreateDelegate(typeof(SetPWMRateDelegate), type.GetMethod("setPWMRate"));
+
+            SetPWMDutyCycle = (SetPWMDutyCycleDelegate)Delegate.CreateDelegate(typeof(SetPWMDutyCycleDelegate), type.GetMethod("setPWMDutyCycle"));
+
+            SetPWMOutputChannel = (SetPWMOutputChannelDelegate)Delegate.CreateDelegate(typeof(SetPWMOutputChannelDelegate), type.GetMethod("setPWMOutputChannel"));
+
+            SetRelayForward = (SetRelayForwardDelegate)Delegate.CreateDelegate(typeof(SetRelayForwardDelegate), type.GetMethod("setRelayForward"));
+
+            SetRelayReverse = (SetRelayReverseDelegate)Delegate.CreateDelegate(typeof(SetRelayReverseDelegate), type.GetMethod("setRelayReverse"));
+
+            GetRelayForward = (GetRelayForwardDelegate)Delegate.CreateDelegate(typeof(GetRelayForwardDelegate), type.GetMethod("getRelayForward"));
+
+            GetRelayReverse = (GetRelayReverseDelegate)Delegate.CreateDelegate(typeof(GetRelayReverseDelegate), type.GetMethod("getRelayReverse"));
+
+            AllocateDIO = (AllocateDIODelegate)Delegate.CreateDelegate(typeof(AllocateDIODelegate), type.GetMethod("allocateDIO"));
+
+            FreeDIO = (FreeDIODelegate)Delegate.CreateDelegate(typeof(FreeDIODelegate), type.GetMethod("freeDIO"));
+
+            SetDIO = (SetDIODelegate)Delegate.CreateDelegate(typeof(SetDIODelegate), type.GetMethod("setDIO"));
+
+            GetDIO = (GetDIODelegate)Delegate.CreateDelegate(typeof(GetDIODelegate), type.GetMethod("getDIO"));
+
+            GetDIODirection = (GetDIODirectionDelegate)Delegate.CreateDelegate(typeof(GetDIODirectionDelegate), type.GetMethod("getDIODirection"));
+
+            Pulse = (PulseDelegate)Delegate.CreateDelegate(typeof(PulseDelegate), type.GetMethod("pulse"));
+
+            IsPulsing = (IsPulsingDelegate)Delegate.CreateDelegate(typeof(IsPulsingDelegate), type.GetMethod("isPulsing"));
+
+            IsAnyPulsing = (IsAnyPulsingDelegate)Delegate.CreateDelegate(typeof(IsAnyPulsingDelegate), type.GetMethod("isAnyPulsing"));
+
+            InitializeCounter = (InitializeCounterDelegate)Delegate.CreateDelegate(typeof(InitializeCounterDelegate), type.GetMethod("initializeCounter"));
+
+            FreeCounter = (FreeCounterDelegate)Delegate.CreateDelegate(typeof(FreeCounterDelegate), type.GetMethod("freeCounter"));
+
+            SetCounterAverageSize = (SetCounterAverageSizeDelegate)Delegate.CreateDelegate(typeof(SetCounterAverageSizeDelegate), type.GetMethod("setCounterAverageSize"));
+
+            SetCounterUpSource = (SetCounterUpSourceDelegate)Delegate.CreateDelegate(typeof(SetCounterUpSourceDelegate), type.GetMethod("setCounterUpSource"));
+
+            SetCounterUpSourceEdge = (SetCounterUpSourceEdgeDelegate)Delegate.CreateDelegate(typeof(SetCounterUpSourceEdgeDelegate), type.GetMethod("setCounterUpSourceEdge"));
+
+            ClearCounterUpSource = (ClearCounterUpSourceDelegate)Delegate.CreateDelegate(typeof(ClearCounterUpSourceDelegate), type.GetMethod("clearCounterUpSource"));
+
+            SetCounterDownSource = (SetCounterDownSourceDelegate)Delegate.CreateDelegate(typeof(SetCounterDownSourceDelegate), type.GetMethod("setCounterDownSource"));
+
+            SetCounterDownSourceEdge = (SetCounterDownSourceEdgeDelegate)Delegate.CreateDelegate(typeof(SetCounterDownSourceEdgeDelegate), type.GetMethod("setCounterDownSourceEdge"));
+
+            ClearCounterDownSource = (ClearCounterDownSourceDelegate)Delegate.CreateDelegate(typeof(ClearCounterDownSourceDelegate), type.GetMethod("clearCounterDownSource"));
+
+            SetCounterUpDownMode = (SetCounterUpDownModeDelegate)Delegate.CreateDelegate(typeof(SetCounterUpDownModeDelegate), type.GetMethod("setCounterUpDownMode"));
+
+            SetCounterExternalDirectionMode = (SetCounterExternalDirectionModeDelegate)Delegate.CreateDelegate(typeof(SetCounterExternalDirectionModeDelegate), type.GetMethod("setCounterExternalDirectionMode"));
+
+            SetCounterSemiPeriodMode = (SetCounterSemiPeriodModeDelegate)Delegate.CreateDelegate(typeof(SetCounterSemiPeriodModeDelegate), type.GetMethod("setCounterSemiPeriodMode"));
+
+            SetCounterPulseLengthMode = (SetCounterPulseLengthModeDelegate)Delegate.CreateDelegate(typeof(SetCounterPulseLengthModeDelegate), type.GetMethod("setCounterPulseLengthMode"));
+
+            GetCounterSamplesToAverage = (GetCounterSamplesToAverageDelegate)Delegate.CreateDelegate(typeof(GetCounterSamplesToAverageDelegate), type.GetMethod("getCounterSamplesToAverage"));
+
+            SetCounterSamplesToAverage = (SetCounterSamplesToAverageDelegate)Delegate.CreateDelegate(typeof(SetCounterSamplesToAverageDelegate), type.GetMethod("setCounterSamplesToAverage"));
+
+            ResetCounter = (ResetCounterDelegate)Delegate.CreateDelegate(typeof(ResetCounterDelegate), type.GetMethod("resetCounter"));
+
+            GetCounter = (GetCounterDelegate)Delegate.CreateDelegate(typeof(GetCounterDelegate), type.GetMethod("getCounter"));
+
+            GetCounterPeriod = (GetCounterPeriodDelegate)Delegate.CreateDelegate(typeof(GetCounterPeriodDelegate), type.GetMethod("getCounterPeriod"));
+
+            SetCounterMaxPeriod = (SetCounterMaxPeriodDelegate)Delegate.CreateDelegate(typeof(SetCounterMaxPeriodDelegate), type.GetMethod("setCounterMaxPeriod"));
+
+            SetCounterUpdateWhenEmpty = (SetCounterUpdateWhenEmptyDelegate)Delegate.CreateDelegate(typeof(SetCounterUpdateWhenEmptyDelegate), type.GetMethod("setCounterUpdateWhenEmpty"));
+
+            GetCounterStopped = (GetCounterStoppedDelegate)Delegate.CreateDelegate(typeof(GetCounterStoppedDelegate), type.GetMethod("getCounterStopped"));
+
+            GetCounterDirection = (GetCounterDirectionDelegate)Delegate.CreateDelegate(typeof(GetCounterDirectionDelegate), type.GetMethod("getCounterDirection"));
+
+            SetCounterReverseDirection = (SetCounterReverseDirectionDelegate)Delegate.CreateDelegate(typeof(SetCounterReverseDirectionDelegate), type.GetMethod("setCounterReverseDirection"));
+
+            InitializeEncoder = (InitializeEncoderDelegate)Delegate.CreateDelegate(typeof(InitializeEncoderDelegate), type.GetMethod("initializeEncoder"));
+
+            FreeEncoder = (FreeEncoderDelegate)Delegate.CreateDelegate(typeof(FreeEncoderDelegate), type.GetMethod("freeEncoder"));
+
+            ResetEncoder = (ResetEncoderDelegate)Delegate.CreateDelegate(typeof(ResetEncoderDelegate), type.GetMethod("resetEncoder"));
+
+            GetEncoder = (GetEncoderDelegate)Delegate.CreateDelegate(typeof(GetEncoderDelegate), type.GetMethod("getEncoder"));
+
+            GetEncoderPeriod = (GetEncoderPeriodDelegate)Delegate.CreateDelegate(typeof(GetEncoderPeriodDelegate), type.GetMethod("getEncoderPeriod"));
+
+            SetEncoderMaxPeriod = (SetEncoderMaxPeriodDelegate)Delegate.CreateDelegate(typeof(SetEncoderMaxPeriodDelegate), type.GetMethod("setEncoderMaxPeriod"));
+
+            GetEncoderStopped = (GetEncoderStoppedDelegate)Delegate.CreateDelegate(typeof(GetEncoderStoppedDelegate), type.GetMethod("getEncoderStopped"));
+
+            GetEncoderDirection = (GetEncoderDirectionDelegate)Delegate.CreateDelegate(typeof(GetEncoderDirectionDelegate), type.GetMethod("getEncoderDirection"));
+
+            SetEncoderReverseDirection = (SetEncoderReverseDirectionDelegate)Delegate.CreateDelegate(typeof(SetEncoderReverseDirectionDelegate), type.GetMethod("setEncoderReverseDirection"));
+
+            SetEncoderSamplesToAverage = (SetEncoderSamplesToAverageDelegate)Delegate.CreateDelegate(typeof(SetEncoderSamplesToAverageDelegate), type.GetMethod("setEncoderSamplesToAverage"));
+
+            GetEncoderSamplesToAverage = (GetEncoderSamplesToAverageDelegate)Delegate.CreateDelegate(typeof(GetEncoderSamplesToAverageDelegate), type.GetMethod("getEncoderSamplesToAverage"));
+
+            SetEncoderIndexSource = (SetEncoderIndexSourceDelegate)Delegate.CreateDelegate(typeof(SetEncoderIndexSourceDelegate), type.GetMethod("setEncoderIndexSource"));
+
+            GetLoopTiming = (GetLoopTimingDelegate)Delegate.CreateDelegate(typeof(GetLoopTimingDelegate), type.GetMethod("getLoopTiming"));
+
+            SpiInitialize = (SpiInitializeDelegate)Delegate.CreateDelegate(typeof(SpiInitializeDelegate), type.GetMethod("spiInitialize"));
+
+            SpiTransaction = (SpiTransactionDelegate)Delegate.CreateDelegate(typeof(SpiTransactionDelegate), type.GetMethod("spiTransaction"));
+
+            SpiWrite = (SpiWriteDelegate)Delegate.CreateDelegate(typeof(SpiWriteDelegate), type.GetMethod("spiWrite"));
+
+            SpiRead = (SpiReadDelegate)Delegate.CreateDelegate(typeof(SpiReadDelegate), type.GetMethod("spiRead"));
+
+            SpiClose = (SpiCloseDelegate)Delegate.CreateDelegate(typeof(SpiCloseDelegate), type.GetMethod("spiClose"));
+
+            SpiSetSpeed = (SpiSetSpeedDelegate)Delegate.CreateDelegate(typeof(SpiSetSpeedDelegate), type.GetMethod("spiSetSpeed"));
+
+            SpiSetBitsPerWord = (SpiSetBitsPerWordDelegate)Delegate.CreateDelegate(typeof(SpiSetBitsPerWordDelegate), type.GetMethod("spiSetBitsPerWord"));
+
+            SpiSetOpts = (SpiSetOptsDelegate)Delegate.CreateDelegate(typeof(SpiSetOptsDelegate), type.GetMethod("spiSetOpts"));
+
+            SpiSetChipSelectActiveHigh = (SpiSetChipSelectActiveHighDelegate)Delegate.CreateDelegate(typeof(SpiSetChipSelectActiveHighDelegate), type.GetMethod("spiSetChipSelectActiveHigh"));
+
+            SpiSetChipSelectActiveLow = (SpiSetChipSelectActiveLowDelegate)Delegate.CreateDelegate(typeof(SpiSetChipSelectActiveLowDelegate), type.GetMethod("spiSetChipSelectActiveLow"));
+
+            SpiGetHandle = (SpiGetHandleDelegate)Delegate.CreateDelegate(typeof(SpiGetHandleDelegate), type.GetMethod("spiGetHandle"));
+
+            SpiSetHandle = (SpiSetHandleDelegate)Delegate.CreateDelegate(typeof(SpiSetHandleDelegate), type.GetMethod("spiSetHandle"));
+
+            SpiGetSemaphore = (SpiGetSemaphoreDelegate)Delegate.CreateDelegate(typeof(SpiGetSemaphoreDelegate), type.GetMethod("spiGetSemaphore"));
+
+            SpiSetSemaphore = (SpiSetSemaphoreDelegate)Delegate.CreateDelegate(typeof(SpiSetSemaphoreDelegate), type.GetMethod("spiSetSemaphore"));
+
+            I2CInitialize = (I2CInitializeDelegate)Delegate.CreateDelegate(typeof(I2CInitializeDelegate), type.GetMethod("i2CInitialize"));
+
+            I2CTransaction = (I2CTransactionDelegate)Delegate.CreateDelegate(typeof(I2CTransactionDelegate), type.GetMethod("i2CTransaction"));
+
+            I2CWrite = (I2CWriteDelegate)Delegate.CreateDelegate(typeof(I2CWriteDelegate), type.GetMethod("i2CWrite"));
+
+            I2CRead = (I2CReadDelegate)Delegate.CreateDelegate(typeof(I2CReadDelegate), type.GetMethod("i2CRead"));
+
+            I2CClose = (I2CCloseDelegate)Delegate.CreateDelegate(typeof(I2CCloseDelegate), type.GetMethod("i2CClose"));
+
+            SetPWMRateIntHack = (SetPWMRateIntHackDelegate)Delegate.CreateDelegate(typeof(SetPWMRateIntHackDelegate), type.GetMethod("setPWMRateIntHack"));
+
+            SetPWMDutyCycleIntHack = (SetPWMDutyCycleIntHackDelegate)Delegate.CreateDelegate(typeof(SetPWMDutyCycleIntHackDelegate), type.GetMethod("setPWMDutyCycleIntHack"));
+        }
+
+        public delegate System.IntPtr InitializeDigitalPortDelegate(System.IntPtr portPointer, ref int status);
+        public static InitializeDigitalPortDelegate InitializeDigitalPort;
+
+        public delegate bool CheckPWMChannelDelegate(System.IntPtr digitalPortPointer);
+        public static CheckPWMChannelDelegate CheckPWMChannel;
+
+        public delegate bool CheckRelayChannelDelegate(System.IntPtr digitalPortPointer);
+        public static CheckRelayChannelDelegate CheckRelayChannel;
+
+        public delegate void SetPWMDelegate(System.IntPtr digitalPortPointer, ushort value, ref int status);
+        public static SetPWMDelegate SetPWM;
+
+        public delegate bool AllocatePWMChannelDelegate(System.IntPtr digitalPortPointer, ref int status);
+        public static AllocatePWMChannelDelegate AllocatePWMChannel;
+
+        public delegate void FreePWMChannelDelegate(System.IntPtr digitalPortPointer, ref int status);
+        public static FreePWMChannelDelegate FreePWMChannel;
+
+        public delegate ushort GetPWMDelegate(System.IntPtr digitalPortPointer, ref int status);
+        public static GetPWMDelegate GetPWM;
+
+        public delegate void LatchPWMZeroDelegate(System.IntPtr digitalPortPointer, ref int status);
+        public static LatchPWMZeroDelegate LatchPWMZero;
+
+        public delegate void SetPWMPeriodScaleDelegate(System.IntPtr digitalPortPointer, uint squelchMask, ref int status);
+        public static SetPWMPeriodScaleDelegate SetPWMPeriodScale;
+
+        public delegate System.IntPtr AllocatePWMDelegate(ref int status);
+        public static AllocatePWMDelegate AllocatePWM;
+
+        public delegate void FreePWMDelegate(System.IntPtr pwmGenerator, ref int status);
+        public static FreePWMDelegate FreePWM;
+
+        public delegate void SetPWMRateDelegate(double rate, ref int status);
+        public static SetPWMRateDelegate SetPWMRate;
+
+        public delegate void SetPWMDutyCycleDelegate(System.IntPtr pwmGenerator, double dutyCycle, ref int status);
+        public static SetPWMDutyCycleDelegate SetPWMDutyCycle;
+
+        public delegate void SetPWMOutputChannelDelegate(System.IntPtr pwmGenerator, uint pin, ref int status);
+        public static SetPWMOutputChannelDelegate SetPWMOutputChannel;
+
+        public delegate void SetRelayForwardDelegate(System.IntPtr digitalPortPointer, [MarshalAs(System.Runtime.InteropServices.UnmanagedType.I1)] bool on, ref int status);
+        public static SetRelayForwardDelegate SetRelayForward;
+
+        public delegate void SetRelayReverseDelegate(System.IntPtr digitalPortPointer, [MarshalAs(System.Runtime.InteropServices.UnmanagedType.I1)] bool on, ref int status);
+        public static SetRelayReverseDelegate SetRelayReverse;
+
+        public delegate bool GetRelayForwardDelegate(System.IntPtr digitalPortPointer, ref int status);
+        public static GetRelayForwardDelegate GetRelayForward;
+
+        public delegate bool GetRelayReverseDelegate(System.IntPtr digitalPortPointer, ref int status);
+        public static GetRelayReverseDelegate GetRelayReverse;
+
+        public delegate bool AllocateDIODelegate(System.IntPtr digitalPortPointer, [MarshalAs(System.Runtime.InteropServices.UnmanagedType.I1)] bool input, ref int status);
+        public static AllocateDIODelegate AllocateDIO;
+
+        public delegate void FreeDIODelegate(System.IntPtr digitalPortPointer, ref int status);
+        public static FreeDIODelegate FreeDIO;
+
+        public delegate void SetDIODelegate(System.IntPtr digitalPortPointer, short value, ref int status);
+        public static SetDIODelegate SetDIO;
+
+        public delegate bool GetDIODelegate(System.IntPtr digitalPortPointer, ref int status);
+        public static GetDIODelegate GetDIO;
+
+        public delegate bool GetDIODirectionDelegate(System.IntPtr digitalPortPointer, ref int status);
+        public static GetDIODirectionDelegate GetDIODirection;
+
+        public delegate void PulseDelegate(System.IntPtr digitalPortPointer, double pulseLength, ref int status);
+        public static PulseDelegate Pulse;
+
+        public delegate bool IsPulsingDelegate(System.IntPtr digitalPortPointer, ref int status);
+        public static IsPulsingDelegate IsPulsing;
+
+        public delegate bool IsAnyPulsingDelegate(ref int status);
+        public static IsAnyPulsingDelegate IsAnyPulsing;
+
+        public delegate System.IntPtr InitializeCounterDelegate(Mode mode, ref uint index, ref int status);
+        public static InitializeCounterDelegate InitializeCounter;
+
+        public delegate void FreeCounterDelegate(System.IntPtr counterPointer, ref int status);
+        public static FreeCounterDelegate FreeCounter;
+
+        public delegate void SetCounterAverageSizeDelegate(System.IntPtr counterPointer, int size, ref int status);
+        public static SetCounterAverageSizeDelegate SetCounterAverageSize;
+
+        public delegate void SetCounterUpSourceDelegate(System.IntPtr counterPointer, uint pin, [MarshalAs(System.Runtime.InteropServices.UnmanagedType.I1)] bool analogTrigger, ref int status);
+        public static SetCounterUpSourceDelegate SetCounterUpSource;
+
+        public delegate void SetCounterUpSourceEdgeDelegate(System.IntPtr counterPointer, [MarshalAs(System.Runtime.InteropServices.UnmanagedType.I1)] bool risingEdge, [MarshalAs(System.Runtime.InteropServices.UnmanagedType.I1)] bool fallingEdge, ref int status);
+        public static SetCounterUpSourceEdgeDelegate SetCounterUpSourceEdge;
+
+        public delegate void ClearCounterUpSourceDelegate(System.IntPtr counterPointer, ref int status);
+        public static ClearCounterUpSourceDelegate ClearCounterUpSource;
+
+        public delegate void SetCounterDownSourceDelegate(System.IntPtr counterPointer, uint pin, [MarshalAs(System.Runtime.InteropServices.UnmanagedType.I1)] bool analogTrigger, ref int status);
+        public static SetCounterDownSourceDelegate SetCounterDownSource;
+
+        public delegate void SetCounterDownSourceEdgeDelegate(System.IntPtr counterPointer, [MarshalAs(System.Runtime.InteropServices.UnmanagedType.I1)] bool risingEdge, [MarshalAs(System.Runtime.InteropServices.UnmanagedType.I1)] bool fallingEdge, ref int status);
+        public static SetCounterDownSourceEdgeDelegate SetCounterDownSourceEdge;
+
+        public delegate void ClearCounterDownSourceDelegate(System.IntPtr counterPointer, ref int status);
+        public static ClearCounterDownSourceDelegate ClearCounterDownSource;
+
+        public delegate void SetCounterUpDownModeDelegate(System.IntPtr counterPointer, ref int status);
+        public static SetCounterUpDownModeDelegate SetCounterUpDownMode;
+
+        public delegate void SetCounterExternalDirectionModeDelegate(System.IntPtr counterPointer, ref int status);
+        public static SetCounterExternalDirectionModeDelegate SetCounterExternalDirectionMode;
+
+        public delegate void SetCounterSemiPeriodModeDelegate(System.IntPtr counterPointer, [MarshalAs(System.Runtime.InteropServices.UnmanagedType.I1)] bool highSemiPeriod, ref int status);
+        public static SetCounterSemiPeriodModeDelegate SetCounterSemiPeriodMode;
+
+        public delegate void SetCounterPulseLengthModeDelegate(System.IntPtr counterPointer, double threshold, ref int status);
+        public static SetCounterPulseLengthModeDelegate SetCounterPulseLengthMode;
+
+        public delegate int GetCounterSamplesToAverageDelegate(System.IntPtr counterPointer, ref int status);
+        public static GetCounterSamplesToAverageDelegate GetCounterSamplesToAverage;
+
+        public delegate void SetCounterSamplesToAverageDelegate(System.IntPtr counterPointer, int samplesToAverage, ref int status);
+        public static SetCounterSamplesToAverageDelegate SetCounterSamplesToAverage;
+
+        public delegate void ResetCounterDelegate(System.IntPtr counterPointer, ref int status);
+        public static ResetCounterDelegate ResetCounter;
+
+        public delegate int GetCounterDelegate(System.IntPtr counterPointer, ref int status);
+        public static GetCounterDelegate GetCounter;
+
+        public delegate double GetCounterPeriodDelegate(System.IntPtr counterPointer, ref int status);
+        public static GetCounterPeriodDelegate GetCounterPeriod;
+
+        public delegate void SetCounterMaxPeriodDelegate(System.IntPtr counterPointer, double maxPeriod, ref int status);
+        public static SetCounterMaxPeriodDelegate SetCounterMaxPeriod;
+
+        public delegate void SetCounterUpdateWhenEmptyDelegate(System.IntPtr counterPointer, [MarshalAs(System.Runtime.InteropServices.UnmanagedType.I1)] bool enabled, ref int status);
+        public static SetCounterUpdateWhenEmptyDelegate SetCounterUpdateWhenEmpty;
+
+        public delegate bool GetCounterStoppedDelegate(System.IntPtr counterPointer, ref int status);
+        public static GetCounterStoppedDelegate GetCounterStopped;
+
+        public delegate bool GetCounterDirectionDelegate(System.IntPtr counterPointer, ref int status);
+        public static GetCounterDirectionDelegate GetCounterDirection;
+
+        public delegate void SetCounterReverseDirectionDelegate(System.IntPtr counterPointer, [MarshalAs(System.Runtime.InteropServices.UnmanagedType.I1)] bool reverseDirection, ref int status);
+        public static SetCounterReverseDirectionDelegate SetCounterReverseDirection;
+
+        public delegate System.IntPtr InitializeEncoderDelegate(byte portAModule, uint portAPin, [MarshalAs(System.Runtime.InteropServices.UnmanagedType.I1)] bool portAAnalogTrigger, byte portBModule, uint portBPin, [MarshalAs(System.Runtime.InteropServices.UnmanagedType.I1)] bool portBAnalogTrigger, [MarshalAs(System.Runtime.InteropServices.UnmanagedType.I1)] bool reverseDirection, ref int index, ref int status);
+        public static InitializeEncoderDelegate InitializeEncoder;
+
+        public delegate void FreeEncoderDelegate(System.IntPtr encoderPointer, ref int status);
+        public static FreeEncoderDelegate FreeEncoder;
+
+        public delegate void ResetEncoderDelegate(System.IntPtr encoderPointer, ref int status);
+        public static ResetEncoderDelegate ResetEncoder;
+
+        public delegate int GetEncoderDelegate(System.IntPtr encoderPointer, ref int status);
+        public static GetEncoderDelegate GetEncoder;
+
+        public delegate double GetEncoderPeriodDelegate(System.IntPtr encoderPointer, ref int status);
+        public static GetEncoderPeriodDelegate GetEncoderPeriod;
+
+        public delegate void SetEncoderMaxPeriodDelegate(System.IntPtr encoderPointer, double maxPeriod, ref int status);
+        public static SetEncoderMaxPeriodDelegate SetEncoderMaxPeriod;
+
+        public delegate bool GetEncoderStoppedDelegate(System.IntPtr encoderPointer, ref int status);
+        public static GetEncoderStoppedDelegate GetEncoderStopped;
+
+        public delegate bool GetEncoderDirectionDelegate(System.IntPtr encoderPointer, ref int status);
+        public static GetEncoderDirectionDelegate GetEncoderDirection;
+
+        public delegate void SetEncoderReverseDirectionDelegate(System.IntPtr encoderPointer, [MarshalAs(System.Runtime.InteropServices.UnmanagedType.I1)] bool reverseDirection, ref int status);
+        public static SetEncoderReverseDirectionDelegate SetEncoderReverseDirection;
+
+        public delegate void SetEncoderSamplesToAverageDelegate(System.IntPtr encoderPointer, uint samplesToAverage, ref int status);
+        public static SetEncoderSamplesToAverageDelegate SetEncoderSamplesToAverage;
+
+        public delegate uint GetEncoderSamplesToAverageDelegate(System.IntPtr encoderPointer, ref int status);
+        public static GetEncoderSamplesToAverageDelegate GetEncoderSamplesToAverage;
+
+        public delegate void SetEncoderIndexSourceDelegate(System.IntPtr encoderPointer, uint pin, [MarshalAs(System.Runtime.InteropServices.UnmanagedType.I1)] bool analogTrigger, [MarshalAs(System.Runtime.InteropServices.UnmanagedType.I1)] bool activeHigh, [MarshalAs(System.Runtime.InteropServices.UnmanagedType.I1)] bool edgeSensitive, ref int status);
+        public static SetEncoderIndexSourceDelegate SetEncoderIndexSource;
+
+        public delegate ushort GetLoopTimingDelegate(ref int status);
+        public static GetLoopTimingDelegate GetLoopTiming;
+
+        public delegate void SpiInitializeDelegate(byte port, ref int status);
+        public static SpiInitializeDelegate SpiInitialize;
+
+        public delegate int SpiTransactionDelegate(byte port, ref byte dataToSend, ref byte dataReceived, byte size);
+        public static SpiTransactionDelegate SpiTransaction;
+
+        public delegate int SpiWriteDelegate(byte port, ref byte dataToSend, byte sendSize);
+        public static SpiWriteDelegate SpiWrite;
+
+        public delegate int SpiReadDelegate(byte port, ref byte buffer, byte count);
+        public static SpiReadDelegate SpiRead;
+
+        public delegate void SpiCloseDelegate(byte port);
+        public static SpiCloseDelegate SpiClose;
+
+        public delegate void SpiSetSpeedDelegate(byte port, uint speed);
+        public static SpiSetSpeedDelegate SpiSetSpeed;
+
+        public delegate void SpiSetBitsPerWordDelegate(byte port, byte bpw);
+        public static SpiSetBitsPerWordDelegate SpiSetBitsPerWord;
+
+        public delegate void SpiSetOptsDelegate(byte port, int msbFirst, int sampleOnTrailing, int clkIdleHigh);
+        public static SpiSetOptsDelegate SpiSetOpts;
+
+        public delegate void SpiSetChipSelectActiveHighDelegate(byte port, ref int status);
+        public static SpiSetChipSelectActiveHighDelegate SpiSetChipSelectActiveHigh;
+
+        public delegate void SpiSetChipSelectActiveLowDelegate(byte port, ref int status);
+        public static SpiSetChipSelectActiveLowDelegate SpiSetChipSelectActiveLow;
+
+        public delegate int SpiGetHandleDelegate(byte port);
+        public static SpiGetHandleDelegate SpiGetHandle;
+
+        public delegate void SpiSetHandleDelegate(byte port, int handle);
+        public static SpiSetHandleDelegate SpiSetHandle;
+
+        public delegate System.IntPtr SpiGetSemaphoreDelegate(byte port);
+        public static SpiGetSemaphoreDelegate SpiGetSemaphore;
+
+        public delegate void SpiSetSemaphoreDelegate(byte port, System.IntPtr semaphore);
+        public static SpiSetSemaphoreDelegate SpiSetSemaphore;
+
+        public delegate void I2CInitializeDelegate(byte port, ref int status);
+        public static I2CInitializeDelegate I2CInitialize;
+
+        public delegate int I2CTransactionDelegate(byte port, byte deviceAddress, ref byte dataToSend, byte sendSize, ref byte dataReceived, byte receiveSize);
+        public static I2CTransactionDelegate I2CTransaction;
+
+        public delegate int I2CWriteDelegate(byte port, byte deviceAddress, ref byte dataToSend, byte sendSize);
+        public static I2CWriteDelegate I2CWrite;
+
+        public delegate int I2CReadDelegate(byte port, byte deviceAddress, ref byte buffer, byte count);
+        public static I2CReadDelegate I2CRead;
+
+        public delegate void I2CCloseDelegate(byte port);
+        public static I2CCloseDelegate I2CClose;
+
+        public delegate void SetPWMRateIntHackDelegate(int rate, ref int status);
+        public static SetPWMRateIntHackDelegate SetPWMRateIntHack;
+
+        public delegate void SetPWMDutyCycleIntHackDelegate(System.IntPtr pwmGenerator, int dutyCycle, ref int status);
+        public static SetPWMDutyCycleIntHackDelegate SetPWMDutyCycleIntHack;
+    }
+}

--- a/HAL-Base/HALInterrupts.cs
+++ b/HAL-Base/HALInterrupts.cs
@@ -1,0 +1,74 @@
+﻿
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace HAL_Base
+{
+    /// Return Type: void
+    ///interruptAssertedMask: unsigned int
+    ///param: void*
+    public delegate void InterruptHandlerFunctionHAL(uint interruptAssertedMask, System.IntPtr param);
+
+    public class HALInterrupts
+    {
+        internal static void SetupDelegates()
+        {
+            string className = MethodBase.GetCurrentMethod().DeclaringType.Name;
+            var types = HAL.HALAssembly.GetTypes();
+            var q = from t in types where t.IsClass && t.Name == className select t;
+
+            Type type = HAL.HALAssembly.GetType(q.ToList()[0].FullName);
+
+            InitializeInterrupts = (InitializeInterruptsDelegate)Delegate.CreateDelegate(typeof(InitializeInterruptsDelegate), type.GetMethod("initializeInterrupts"));
+
+            CleanInterrupts = (CleanInterruptsDelegate)Delegate.CreateDelegate(typeof(CleanInterruptsDelegate), type.GetMethod("cleanInterrupts"));
+
+            WaitForInterrupt = (WaitForInterruptDelegate)Delegate.CreateDelegate(typeof(WaitForInterruptDelegate), type.GetMethod("waitForInterrupt"));
+
+            EnableInterrupts = (EnableInterruptsDelegate)Delegate.CreateDelegate(typeof(EnableInterruptsDelegate), type.GetMethod("enableInterrupts"));
+
+            DisableInterrupts = (DisableInterruptsDelegate)Delegate.CreateDelegate(typeof(DisableInterruptsDelegate), type.GetMethod("disableInterrupts"));
+
+            ReadRisingTimestamp = (ReadRisingTimestampDelegate)Delegate.CreateDelegate(typeof(ReadRisingTimestampDelegate), type.GetMethod("readRisingTimestamp"));
+
+            ReadFallingTimestamp = (ReadFallingTimestampDelegate)Delegate.CreateDelegate(typeof(ReadFallingTimestampDelegate), type.GetMethod("readFallingTimestamp"));
+
+            RequestInterrupts = (RequestInterruptsDelegate)Delegate.CreateDelegate(typeof(RequestInterruptsDelegate), type.GetMethod("requestInterrupts"));
+
+            AttachInterruptHandler = (AttachInterruptHandlerDelegate)Delegate.CreateDelegate(typeof(AttachInterruptHandlerDelegate), type.GetMethod("attachInterruptHandler"));
+
+            SetInterruptUpSourceEdge = (SetInterruptUpSourceEdgeDelegate)Delegate.CreateDelegate(typeof(SetInterruptUpSourceEdgeDelegate), type.GetMethod("setInterruptUpSourceEdge"));
+        }
+
+        public delegate System.IntPtr InitializeInterruptsDelegate(uint interruptIndex, [System.Runtime.InteropServices.MarshalAsAttribute(System.Runtime.InteropServices.UnmanagedType.I1)] bool watcher, ref int status);
+        public static InitializeInterruptsDelegate InitializeInterrupts;
+
+        public delegate void CleanInterruptsDelegate(System.IntPtr interruptPointer, ref int status);
+        public static CleanInterruptsDelegate CleanInterrupts;
+
+        public delegate uint WaitForInterruptDelegate(System.IntPtr interruptPointer, double timeout, [System.Runtime.InteropServices.MarshalAsAttribute(System.Runtime.InteropServices.UnmanagedType.I1)] bool ignorePrevious, ref int status);
+        public static WaitForInterruptDelegate WaitForInterrupt;
+
+        public delegate void EnableInterruptsDelegate(System.IntPtr interruptPointer, ref int status);
+        public static EnableInterruptsDelegate EnableInterrupts;
+
+        public delegate void DisableInterruptsDelegate(System.IntPtr interruptPointer, ref int status);
+        public static DisableInterruptsDelegate DisableInterrupts;
+
+        public delegate double ReadRisingTimestampDelegate(System.IntPtr interruptPointer, ref int status);
+        public static ReadRisingTimestampDelegate ReadRisingTimestamp;
+
+        public delegate double ReadFallingTimestampDelegate(System.IntPtr interruptPointer, ref int status);
+        public static ReadFallingTimestampDelegate ReadFallingTimestamp;
+
+        public delegate void RequestInterruptsDelegate(System.IntPtr interruptPointer, byte routingModule, uint routingPin, [System.Runtime.InteropServices.MarshalAsAttribute(System.Runtime.InteropServices.UnmanagedType.I1)] bool routingAnalogTrigger, ref int status);
+        public static RequestInterruptsDelegate RequestInterrupts;
+
+        public delegate void AttachInterruptHandlerDelegate(System.IntPtr interruptPointer, InterruptHandlerFunctionHAL handler, System.IntPtr param, ref int status);
+        public static AttachInterruptHandlerDelegate AttachInterruptHandler;
+
+        public delegate void SetInterruptUpSourceEdgeDelegate(System.IntPtr interruptPointer, [System.Runtime.InteropServices.MarshalAsAttribute(System.Runtime.InteropServices.UnmanagedType.I1)] bool risingEdge, [System.Runtime.InteropServices.MarshalAsAttribute(System.Runtime.InteropServices.UnmanagedType.I1)] bool fallingEdge, ref int status);
+        public static SetInterruptUpSourceEdgeDelegate SetInterruptUpSourceEdge;
+    }
+}

--- a/HAL-Base/HALNotifier.cs
+++ b/HAL-Base/HALNotifier.cs
@@ -1,0 +1,39 @@
+﻿
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace HAL_Base
+{
+    /// Return Type: void
+    ///param0: unsigned int
+    ///param1: void*
+    public delegate void NotifierDelegate(uint param0, System.IntPtr param1);
+
+    public class HALNotifier
+    {
+        internal static void SetupDelegates()
+        {
+            string className = MethodBase.GetCurrentMethod().DeclaringType.Name;
+            var types = HAL.HALAssembly.GetTypes();
+            var q = from t in types where t.IsClass && t.Name == className select t;
+
+            Type type = HAL.HALAssembly.GetType(q.ToList()[0].FullName);
+
+            InitializeNotifier = (InitializeNotifierDelegate)Delegate.CreateDelegate(typeof(InitializeNotifierDelegate), type.GetMethod("initializeNotifier"));
+
+            CleanNotifier = (CleanNotifierDelegate)Delegate.CreateDelegate(typeof(CleanNotifierDelegate), type.GetMethod("cleanNotifier"));
+
+            UpdateNotifierAlarm = (UpdateNotifierAlarmDelegate)Delegate.CreateDelegate(typeof(UpdateNotifierAlarmDelegate), type.GetMethod("updateNotifierAlarm"));
+        }
+
+        public delegate System.IntPtr InitializeNotifierDelegate(NotifierDelegate processQueue, ref int status);
+        public static InitializeNotifierDelegate InitializeNotifier;
+
+        public delegate void CleanNotifierDelegate(System.IntPtr notifierPointer, ref int status);
+        public static CleanNotifierDelegate CleanNotifier;
+
+        public delegate void UpdateNotifierAlarmDelegate(System.IntPtr notifierPointer, uint triggerTime, ref int status);
+        public static UpdateNotifierAlarmDelegate UpdateNotifierAlarm;
+    }
+}

--- a/HAL-Base/HALPDP.cs
+++ b/HAL-Base/HALPDP.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+
+namespace HAL_Base
+{
+    public class HALPDP
+    {
+        internal static void SetupDelegates()
+        {
+            string className = MethodBase.GetCurrentMethod().DeclaringType.Name;
+            var types = HAL.HALAssembly.GetTypes();
+            var q = from t in types where t.IsClass && t.Name == className select t;
+
+            Type type = HAL.HALAssembly.GetType(q.ToList()[0].FullName);
+
+            GetPDPTemperature = (GetPDPTemperatureDelegate)Delegate.CreateDelegate(typeof(GetPDPTemperatureDelegate), type.GetMethod("getPDPTemperature"));
+
+            GetPDPVoltage = (GetPDPVoltageDelegate)Delegate.CreateDelegate(typeof(GetPDPVoltageDelegate), type.GetMethod("getPDPVoltage"));
+
+            GetPDPChannelCurrent = (GetPDPChannelCurrentDelegate)Delegate.CreateDelegate(typeof(GetPDPChannelCurrentDelegate), type.GetMethod("getPDPChannelCurrent"));
+
+            GetPDPTotalCurrent = (GetPDPTotalCurrentDelegate)Delegate.CreateDelegate(typeof(GetPDPTotalCurrentDelegate), type.GetMethod("getPDPTotalCurrent"));
+
+            GetPDPTotalPower = (GetPDPTotalPowerDelegate)Delegate.CreateDelegate(typeof(GetPDPTotalPowerDelegate), type.GetMethod("getPDPTotalPower"));
+
+            GetPDPTotalEnergy = (GetPDPTotalEnergyDelegate)Delegate.CreateDelegate(typeof(GetPDPTotalEnergyDelegate), type.GetMethod("getPDPTotalEnergy"));
+
+            ResetPDPTotalEnergy = (ResetPDPTotalEnergyDelegate)Delegate.CreateDelegate(typeof(ResetPDPTotalEnergyDelegate), type.GetMethod("resetPDPTotalEnergy"));
+
+            ClearPDPStickyFaults = (ClearPDPStickyFaultsDelegate)Delegate.CreateDelegate(typeof(ClearPDPStickyFaultsDelegate), type.GetMethod("clearPDPStickyFaults"));
+        }
+
+        public delegate double GetPDPTemperatureDelegate(ref int status);
+        public static GetPDPTemperatureDelegate GetPDPTemperature;
+
+        public delegate double GetPDPVoltageDelegate(ref int status);
+        public static GetPDPVoltageDelegate GetPDPVoltage;
+
+        public delegate double GetPDPChannelCurrentDelegate(byte channel, ref int status);
+        public static GetPDPChannelCurrentDelegate GetPDPChannelCurrent;
+
+        public delegate double GetPDPTotalCurrentDelegate(ref int status);
+        public static GetPDPTotalCurrentDelegate GetPDPTotalCurrent;
+
+        public delegate double GetPDPTotalPowerDelegate(ref int status);
+        public static GetPDPTotalPowerDelegate GetPDPTotalPower;
+
+        public delegate double GetPDPTotalEnergyDelegate(ref int status);
+        public static GetPDPTotalEnergyDelegate GetPDPTotalEnergy;
+
+        public delegate void ResetPDPTotalEnergyDelegate(ref int status);
+        public static ResetPDPTotalEnergyDelegate ResetPDPTotalEnergy;
+
+        public delegate void ClearPDPStickyFaultsDelegate(ref int status);
+        public static ClearPDPStickyFaultsDelegate ClearPDPStickyFaults;
+    }
+}

--- a/HAL-Base/HALPower.cs
+++ b/HAL-Base/HALPower.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+
+namespace HAL_Base
+{
+    public class HALPower
+    {
+        internal static void SetupDelegates()
+        {
+            string className = MethodBase.GetCurrentMethod().DeclaringType.Name;
+            var types = HAL.HALAssembly.GetTypes();
+            var q = from t in types where t.IsClass && t.Name == className select t;
+
+            Type type = HAL.HALAssembly.GetType(q.ToList()[0].FullName);
+
+            GetVinVoltage = (GetVinVoltageDelegate)Delegate.CreateDelegate(typeof(GetVinVoltageDelegate), type.GetMethod("getVinVoltage"));
+
+            GetVinCurrent = (GetVinCurrentDelegate)Delegate.CreateDelegate(typeof(GetVinCurrentDelegate), type.GetMethod("getVinCurrent"));
+
+            GetUserVoltage6V = (GetUserVoltage6VDelegate)Delegate.CreateDelegate(typeof(GetUserVoltage6VDelegate), type.GetMethod("getUserVoltage6V"));
+
+            GetUserCurrent6V = (GetUserCurrent6VDelegate)Delegate.CreateDelegate(typeof(GetUserCurrent6VDelegate), type.GetMethod("getUserCurrent6V"));
+
+            GetUserActive6V = (GetUserActive6VDelegate)Delegate.CreateDelegate(typeof(GetUserActive6VDelegate), type.GetMethod("getUserActive6V"));
+
+            GetUserCurrentFaults6V = (GetUserCurrentFaults6VDelegate)Delegate.CreateDelegate(typeof(GetUserCurrentFaults6VDelegate), type.GetMethod("getUserCurrentFaults6V"));
+
+            GetUserVoltage5V = (GetUserVoltage5VDelegate)Delegate.CreateDelegate(typeof(GetUserVoltage5VDelegate), type.GetMethod("getUserVoltage5V"));
+
+            GetUserCurrent5V = (GetUserCurrent5VDelegate)Delegate.CreateDelegate(typeof(GetUserCurrent5VDelegate), type.GetMethod("getUserCurrent5V"));
+
+            GetUserActive5V = (GetUserActive5VDelegate)Delegate.CreateDelegate(typeof(GetUserActive5VDelegate), type.GetMethod("getUserActive5V"));
+
+            GetUserCurrentFaults5V = (GetUserCurrentFaults5VDelegate)Delegate.CreateDelegate(typeof(GetUserCurrentFaults5VDelegate), type.GetMethod("getUserCurrentFaults5V"));
+
+            GetUserVoltage3V3 = (GetUserVoltage3V3Delegate)Delegate.CreateDelegate(typeof(GetUserVoltage3V3Delegate), type.GetMethod("getUserVoltage3V3"));
+
+            GetUserCurrent3V3 = (GetUserCurrent3V3Delegate)Delegate.CreateDelegate(typeof(GetUserCurrent3V3Delegate), type.GetMethod("getUserCurrent3V3"));
+
+            GetUserActive3V3 = (GetUserActive3V3Delegate)Delegate.CreateDelegate(typeof(GetUserActive3V3Delegate), type.GetMethod("getUserActive3V3"));
+
+            GetUserCurrentFaults3V3 = (GetUserCurrentFaults3V3Delegate)Delegate.CreateDelegate(typeof(GetUserCurrentFaults3V3Delegate), type.GetMethod("getUserCurrentFaults3V3"));
+        }
+
+        public delegate float GetVinVoltageDelegate(ref int status);
+        public static GetVinVoltageDelegate GetVinVoltage;
+
+        public delegate float GetVinCurrentDelegate(ref int status);
+        public static GetVinCurrentDelegate GetVinCurrent;
+
+        public delegate float GetUserVoltage6VDelegate(ref int status);
+        public static GetUserVoltage6VDelegate GetUserVoltage6V;
+
+        public delegate float GetUserCurrent6VDelegate(ref int status);
+        public static GetUserCurrent6VDelegate GetUserCurrent6V;
+
+        public delegate bool GetUserActive6VDelegate(ref int status);
+        public static GetUserActive6VDelegate GetUserActive6V;
+
+        public delegate int GetUserCurrentFaults6VDelegate(ref int status);
+        public static GetUserCurrentFaults6VDelegate GetUserCurrentFaults6V;
+
+        public delegate float GetUserVoltage5VDelegate(ref int status);
+        public static GetUserVoltage5VDelegate GetUserVoltage5V;
+
+        public delegate float GetUserCurrent5VDelegate(ref int status);
+        public static GetUserCurrent5VDelegate GetUserCurrent5V;
+
+        public delegate bool GetUserActive5VDelegate(ref int status);
+        public static GetUserActive5VDelegate GetUserActive5V;
+
+        public delegate int GetUserCurrentFaults5VDelegate(ref int status);
+        public static GetUserCurrentFaults5VDelegate GetUserCurrentFaults5V;
+
+        public delegate float GetUserVoltage3V3Delegate(ref int status);
+        public static GetUserVoltage3V3Delegate GetUserVoltage3V3;
+
+        public delegate float GetUserCurrent3V3Delegate(ref int status);
+        public static GetUserCurrent3V3Delegate GetUserCurrent3V3;
+
+        public delegate bool GetUserActive3V3Delegate(ref int status);
+        public static GetUserActive3V3Delegate GetUserActive3V3;
+
+        public delegate int GetUserCurrentFaults3V3Delegate(ref int status);
+        public static GetUserCurrentFaults3V3Delegate GetUserCurrentFaults3V3;
+    }
+}

--- a/HAL-Base/HALSemaphore.cs
+++ b/HAL-Base/HALSemaphore.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace HAL_Base
+{
+    public class HALSemaphore
+    {
+        internal static void SetupDelegates()
+        {
+            string className = MethodBase.GetCurrentMethod().DeclaringType.Name;
+            var types = HAL.HALAssembly.GetTypes();
+            var q = from t in types where t.IsClass && t.Name == className select t;
+
+            Type type = HAL.HALAssembly.GetType(q.ToList()[0].FullName);
+
+            InitializeMutexRecursive = (InitializeMutexRecursiveDelegate)Delegate.CreateDelegate(typeof(InitializeMutexRecursiveDelegate), type.GetMethod("InitializeMutexRecursive"));
+
+            InitializeMutexNormal = (InitializeMutexNormalDelegate)Delegate.CreateDelegate(typeof(InitializeMutexNormalDelegate), type.GetMethod("initializeMutexNormal"));
+
+            DeleteMutex = (DeleteMutexDelegate)Delegate.CreateDelegate(typeof(DeleteMutexDelegate), type.GetMethod("deleteMutex"));
+
+            TakeMutex = (TakeMutexDelegate)Delegate.CreateDelegate(typeof(TakeMutexDelegate), type.GetMethod("takeMutex"));
+
+            TryTakeMutex = (TryTakeMutexDelegate)Delegate.CreateDelegate(typeof(TryTakeMutexDelegate), type.GetMethod("tryTakeMutex"));
+
+            GiveMutex = (GiveMutexDelegate)Delegate.CreateDelegate(typeof(GiveMutexDelegate), type.GetMethod("giveMutex"));
+
+            InitializeSemaphore = (InitializeSemaphoreDelegate)Delegate.CreateDelegate(typeof(InitializeSemaphoreDelegate), type.GetMethod("initializeSemaphore"));
+
+            DeleteSemaphore = (DeleteSemaphoreDelegate)Delegate.CreateDelegate(typeof(DeleteSemaphoreDelegate), type.GetMethod("deleteSemaphore"));
+
+            TakeSemaphore = (TakeSemaphoreDelegate)Delegate.CreateDelegate(typeof(TakeSemaphoreDelegate), type.GetMethod("takeSemaphore"));
+
+            TryTakeSemaphore = (TryTakeSemaphoreDelegate)Delegate.CreateDelegate(typeof(TryTakeSemaphoreDelegate), type.GetMethod("tryTakeSemaphore"));
+
+            GiveSemaphore = (GiveSemaphoreDelegate)Delegate.CreateDelegate(typeof(GiveSemaphoreDelegate), type.GetMethod("giveSemaphore"));
+
+            InitializeMultiWait = (InitializeMultiWaitDelegate)Delegate.CreateDelegate(typeof(InitializeMultiWaitDelegate), type.GetMethod("initializeMultiWait"));
+
+            DeleteMultiWait = (DeleteMultiWaitDelegate)Delegate.CreateDelegate(typeof(DeleteMultiWaitDelegate), type.GetMethod("deleteMultiWait"));
+
+            TakeMultiWait = (TakeMultiWaitDelegate)Delegate.CreateDelegate(typeof(TakeMultiWaitDelegate), type.GetMethod("takeMultiWait"));
+
+            GiveMultiWait = (GiveMultiWaitDelegate)Delegate.CreateDelegate(typeof(GiveMultiWaitDelegate), type.GetMethod("giveMultiWait"));
+        }
+
+        public delegate System.IntPtr InitializeMutexRecursiveDelegate();
+        public static InitializeMutexRecursiveDelegate InitializeMutexRecursive;
+
+        public delegate System.IntPtr InitializeMutexNormalDelegate();
+        public static InitializeMutexNormalDelegate InitializeMutexNormal;
+
+        public delegate void DeleteMutexDelegate(System.IntPtr sem);
+        public static DeleteMutexDelegate DeleteMutex;
+
+        public delegate byte TakeMutexDelegate(System.IntPtr sem);
+        public static TakeMutexDelegate TakeMutex;
+
+        public delegate byte TryTakeMutexDelegate(System.IntPtr sem);
+        public static TryTakeMutexDelegate TryTakeMutex;
+
+        public delegate byte GiveMutexDelegate(System.IntPtr sem);
+        public static GiveMutexDelegate GiveMutex;
+
+        public delegate System.IntPtr InitializeSemaphoreDelegate(uint initialValue);
+        public static InitializeSemaphoreDelegate InitializeSemaphore;
+
+        public delegate void DeleteSemaphoreDelegate(System.IntPtr sem);
+        public static DeleteSemaphoreDelegate DeleteSemaphore;
+
+        public delegate byte TakeSemaphoreDelegate(System.IntPtr sem);
+        public static TakeSemaphoreDelegate TakeSemaphore;
+
+        public delegate byte TryTakeSemaphoreDelegate(System.IntPtr sem);
+        public static TryTakeSemaphoreDelegate TryTakeSemaphore;
+
+        public delegate byte GiveSemaphoreDelegate(System.IntPtr sem);
+        public static GiveSemaphoreDelegate GiveSemaphore;
+
+        public delegate System.IntPtr InitializeMultiWaitDelegate();
+        public static InitializeMultiWaitDelegate InitializeMultiWait;
+
+        public delegate void DeleteMultiWaitDelegate(System.IntPtr sem);
+        public static DeleteMultiWaitDelegate DeleteMultiWait;
+
+        public delegate byte TakeMultiWaitDelegate(System.IntPtr sem, System.IntPtr m, int timeout);
+        public static TakeMultiWaitDelegate TakeMultiWait;
+
+        public delegate byte GiveMultiWaitDelegate(System.IntPtr sem);
+        public static GiveMultiWaitDelegate GiveMultiWait;
+    }
+}

--- a/HAL-Base/HALSerialPort.cs
+++ b/HAL-Base/HALSerialPort.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+
+namespace HAL_Base
+{
+    public class HALSerialPort
+    {
+        internal static void SetupDelegates()
+        {
+            string className = MethodBase.GetCurrentMethod().DeclaringType.Name;
+            var types = HAL.HALAssembly.GetTypes();
+            var q = from t in types where t.IsClass && t.Name == className select t;
+
+            Type type = HAL.HALAssembly.GetType(q.ToList()[0].FullName);
+
+            SerialInitializePort = (SerialInitializePortDelegate)Delegate.CreateDelegate(typeof(SerialInitializePortDelegate), type.GetMethod("serialInitializePort"));
+
+            SerialSetBaudRate = (SerialSetBaudRateDelegate)Delegate.CreateDelegate(typeof(SerialSetBaudRateDelegate), type.GetMethod("serialSetBaudRate"));
+
+            SerialSetDataBits = (SerialSetDataBitsDelegate)Delegate.CreateDelegate(typeof(SerialSetDataBitsDelegate), type.GetMethod("serialSetDataBits"));
+
+            SerialSetParity = (SerialSetParityDelegate)Delegate.CreateDelegate(typeof(SerialSetParityDelegate), type.GetMethod("serialSetParity"));
+
+            SerialSetStopBits = (SerialSetStopBitsDelegate)Delegate.CreateDelegate(typeof(SerialSetStopBitsDelegate), type.GetMethod("serialSetStopBits"));
+
+            SerialSetWriteMode = (SerialSetWriteModeDelegate)Delegate.CreateDelegate(typeof(SerialSetWriteModeDelegate), type.GetMethod("serialSetWriteMode"));
+
+            SerialSetFlowControl = (SerialSetFlowControlDelegate)Delegate.CreateDelegate(typeof(SerialSetFlowControlDelegate), type.GetMethod("serialSetFlowControl"));
+
+            SerialSetTimeout = (SerialSetTimeoutDelegate)Delegate.CreateDelegate(typeof(SerialSetTimeoutDelegate), type.GetMethod("serialSetTimeout"));
+
+            SerialEnableTermination = (SerialEnableTerminationDelegate)Delegate.CreateDelegate(typeof(SerialEnableTerminationDelegate), type.GetMethod("serialEnableTermination"));
+
+            SerialDisableTermination = (SerialDisableTerminationDelegate)Delegate.CreateDelegate(typeof(SerialDisableTerminationDelegate), type.GetMethod("serialDisableTermination"));
+
+            SerialSetReadBufferSize = (SerialSetReadBufferSizeDelegate)Delegate.CreateDelegate(typeof(SerialSetReadBufferSizeDelegate), type.GetMethod("serialSetReadBufferSize"));
+
+            SerialSetWriteBufferSize = (SerialSetWriteBufferSizeDelegate)Delegate.CreateDelegate(typeof(SerialSetWriteBufferSizeDelegate), type.GetMethod("serialSetWriteBufferSize"));
+
+            SerialGetBytesReceived = (SerialGetBytesReceivedDelegate)Delegate.CreateDelegate(typeof(SerialGetBytesReceivedDelegate), type.GetMethod("serialGetBytesReceived"));
+
+            SerialRead = (SerialReadDelegate)Delegate.CreateDelegate(typeof(SerialReadDelegate), type.GetMethod("serialRead"));
+
+            SerialWrite = (SerialWriteDelegate)Delegate.CreateDelegate(typeof(SerialWriteDelegate), type.GetMethod("serialWrite"));
+
+            SerialFlush = (SerialFlushDelegate)Delegate.CreateDelegate(typeof(SerialFlushDelegate), type.GetMethod("serialFlush"));
+
+            SerialClear = (SerialClearDelegate)Delegate.CreateDelegate(typeof(SerialClearDelegate), type.GetMethod("serialClear"));
+
+            SerialClose = (SerialCloseDelegate)Delegate.CreateDelegate(typeof(SerialCloseDelegate), type.GetMethod("serialClose"));
+        }
+
+        public delegate void SerialInitializePortDelegate(byte port, ref int status);
+        public static SerialInitializePortDelegate SerialInitializePort;
+
+        public delegate void SerialSetBaudRateDelegate(byte port, uint baud, ref int status);
+        public static SerialSetBaudRateDelegate SerialSetBaudRate;
+
+        public delegate void SerialSetDataBitsDelegate(byte port, byte bits, ref int status);
+        public static SerialSetDataBitsDelegate SerialSetDataBits;
+
+        public delegate void SerialSetParityDelegate(byte port, byte parity, ref int status);
+        public static SerialSetParityDelegate SerialSetParity;
+
+        public delegate void SerialSetStopBitsDelegate(byte port, byte stopBits, ref int status);
+        public static SerialSetStopBitsDelegate SerialSetStopBits;
+
+        public delegate void SerialSetWriteModeDelegate(byte port, byte mode, ref int status);
+        public static SerialSetWriteModeDelegate SerialSetWriteMode;
+
+        public delegate void SerialSetFlowControlDelegate(byte port, byte flow, ref int status);
+        public static SerialSetFlowControlDelegate SerialSetFlowControl;
+
+        public delegate void SerialSetTimeoutDelegate(byte port, float timeout, ref int status);
+        public static SerialSetTimeoutDelegate SerialSetTimeout;
+
+        public delegate void SerialEnableTerminationDelegate(byte port, byte terminator, ref int status);
+        public static SerialEnableTerminationDelegate SerialEnableTermination;
+
+        public delegate void SerialDisableTerminationDelegate(byte port, ref int status);
+        public static SerialDisableTerminationDelegate SerialDisableTermination;
+
+        public delegate void SerialSetReadBufferSizeDelegate(byte port, uint size, ref int status);
+        public static SerialSetReadBufferSizeDelegate SerialSetReadBufferSize;
+
+        public delegate void SerialSetWriteBufferSizeDelegate(byte port, uint size, ref int status);
+        public static SerialSetWriteBufferSizeDelegate SerialSetWriteBufferSize;
+
+        public delegate int SerialGetBytesReceivedDelegate(byte port, ref int status);
+        public static SerialGetBytesReceivedDelegate SerialGetBytesReceived;
+
+        public delegate uint SerialReadDelegate(byte port, System.IntPtr buffer, int count, ref int status);
+        public static SerialReadDelegate SerialRead;
+
+        public delegate uint SerialWriteDelegate(byte port, [System.Runtime.InteropServices.InAttribute()] [System.Runtime.InteropServices.MarshalAsAttribute(System.Runtime.InteropServices.UnmanagedType.LPStr)] string buffer, int count, ref int status);
+        public static SerialWriteDelegate SerialWrite;
+
+        public delegate void SerialFlushDelegate(byte port, ref int status);
+        public static SerialFlushDelegate SerialFlush;
+
+        public delegate void SerialClearDelegate(byte port, ref int status);
+        public static SerialClearDelegate SerialClear;
+
+        public delegate void SerialCloseDelegate(byte port, ref int status);
+        public static SerialCloseDelegate SerialClose;
+    }
+}

--- a/HAL-Base/HALSolenoid.cs
+++ b/HAL-Base/HALSolenoid.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+
+namespace HAL_Base
+{
+    public class HALSolenoid
+    {
+        internal static void SetupDelegates()
+        {
+            string className = MethodBase.GetCurrentMethod().DeclaringType.Name;
+            var types = HAL.HALAssembly.GetTypes();
+            var q = from t in types where t.IsClass && t.Name == className select t;
+
+            Type type = HAL.HALAssembly.GetType(q.ToList()[0].FullName);
+
+            InitializeSolenoidPort = (InitializeSolenoidPortDelegate)Delegate.CreateDelegate(typeof(InitializeSolenoidPortDelegate), type.GetMethod("initializeSolenoidPort"));
+
+            CheckSolenoidModule = (CheckSolenoidModuleDelegate)Delegate.CreateDelegate(typeof(CheckSolenoidModuleDelegate), type.GetMethod("checkSolenoidModule"));
+
+            GetSolenoid = (GetSolenoidDelegate)Delegate.CreateDelegate(typeof(GetSolenoidDelegate), type.GetMethod("getSolenoid"));
+
+            SetSolenoid = (SetSolenoidDelegate)Delegate.CreateDelegate(typeof(SetSolenoidDelegate), type.GetMethod("setSolenoid"));
+
+            GetPCMSolenoidBlackList = (GetPCMSolenoidBlackListDelegate)Delegate.CreateDelegate(typeof(GetPCMSolenoidBlackListDelegate), type.GetMethod("getPCMSolenoidBlackList"));
+
+            GetPCMSolenoidVoltageStickyFault = (GetPCMSolenoidVoltageStickyFaultDelegate)Delegate.CreateDelegate(typeof(GetPCMSolenoidVoltageStickyFaultDelegate), type.GetMethod("getPCMSolenoidVoltageStickyFault"));
+
+            GetPCMSolenoidVoltageFault = (GetPCMSolenoidVoltageFaultDelegate)Delegate.CreateDelegate(typeof(GetPCMSolenoidVoltageFaultDelegate), type.GetMethod("getPCMSolenoidVoltageFault"));
+
+            ClearAllPCMStickyFaults_sol = (ClearAllPCMStickyFaults_solDelegate)Delegate.CreateDelegate(typeof(ClearAllPCMStickyFaults_solDelegate), type.GetMethod("clearAllPCMStickyFaults_sol"));
+        }
+
+        public delegate System.IntPtr InitializeSolenoidPortDelegate(System.IntPtr portPointer, ref int status);
+        public static InitializeSolenoidPortDelegate InitializeSolenoidPort;
+
+        public delegate bool CheckSolenoidModuleDelegate(byte module);
+        public static CheckSolenoidModuleDelegate CheckSolenoidModule;
+
+        public delegate bool GetSolenoidDelegate(System.IntPtr solenoidPortPointer, ref int status);
+        public static GetSolenoidDelegate GetSolenoid;
+
+        public delegate void SetSolenoidDelegate(System.IntPtr solenoidPortPointer, [System.Runtime.InteropServices.MarshalAsAttribute(System.Runtime.InteropServices.UnmanagedType.I1)] bool value, ref int status);
+        public static SetSolenoidDelegate SetSolenoid;
+
+        public delegate int GetPCMSolenoidBlackListDelegate(System.IntPtr solenoidPortPointer, ref int status);
+        public static GetPCMSolenoidBlackListDelegate GetPCMSolenoidBlackList;
+
+        public delegate bool GetPCMSolenoidVoltageStickyFaultDelegate(System.IntPtr solenoidPortPointer, ref int status);
+        public static GetPCMSolenoidVoltageStickyFaultDelegate GetPCMSolenoidVoltageStickyFault;
+
+        public delegate bool GetPCMSolenoidVoltageFaultDelegate(System.IntPtr solenoidPortPointer, ref int status);
+        public static GetPCMSolenoidVoltageFaultDelegate GetPCMSolenoidVoltageFault;
+
+        public delegate void ClearAllPCMStickyFaults_solDelegate(System.IntPtr solenoidPortPointer, ref int status);
+        public static ClearAllPCMStickyFaults_solDelegate ClearAllPCMStickyFaults_sol;
+    }
+}

--- a/HAL-Base/HALUsageReporter.cs
+++ b/HAL-Base/HALUsageReporter.cs
@@ -1,5 +1,5 @@
 ﻿// ReSharper disable InconsistentNaming
-namespace HAL_FRC
+namespace HAL_Base
 {
     public enum ResourceType
     {

--- a/HAL-Base/HALUtilities.cs
+++ b/HAL-Base/HALUtilities.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+
+namespace HAL_Base
+{
+    public class HALUtilities
+    {
+        internal static void SetupDelegates()
+        {
+            string className = MethodBase.GetCurrentMethod().DeclaringType.Name;
+            var types = HAL.HALAssembly.GetTypes();
+            var q = from t in types where t.IsClass && t.Name == className select t;
+
+            Type type = HAL.HALAssembly.GetType(q.ToList()[0].FullName);
+
+            DelayTicks = (DelayTicksDelegate)Delegate.CreateDelegate(typeof(DelayTicksDelegate), type.GetMethod("delayTicks"));
+
+            DelayMillis = (DelayMillisDelegate)Delegate.CreateDelegate(typeof(DelayMillisDelegate), type.GetMethod("delayMillis"));
+
+            DelaySeconds = (DelaySecondsDelegate)Delegate.CreateDelegate(typeof(DelaySecondsDelegate), type.GetMethod("delaySeconds"));
+        }
+
+        public delegate void DelayTicksDelegate(int ticks);
+        public static DelayTicksDelegate DelayTicks;
+
+        public delegate void DelayMillisDelegate(double ms);
+        public static DelayMillisDelegate DelayMillis;
+
+        public delegate void DelaySecondsDelegate(double s);
+        public static DelaySecondsDelegate DelaySeconds;
+
+        public static int PARAMETER_OUT_OF_RANGE = -1028;
+    }
+}

--- a/HAL-Base/Properties/AssemblyInfo.cs
+++ b/HAL-Base/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("HAL-Base")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("HAL-Base")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("af101b13-bca8-42d5-8eff-f63ae0a50b2b")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/HAL-RoboRIO/HAL-RoboRIO.csproj
+++ b/HAL-RoboRIO/HAL-RoboRIO.csproj
@@ -24,9 +24,9 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
-    <Optimize>false</Optimize>
+    <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/HAL-RoboRIO/HAL.cs
+++ b/HAL-RoboRIO/HAL.cs
@@ -1,89 +1,12 @@
 ﻿using System;
 using System.Reflection;
+using HAL_Base;
 
 
-namespace HAL_FRC
+namespace HAL_RoboRIO
 {
-    public enum HALAllianceStationID
-    {
-// ReSharper disable InconsistentNaming
-        HALAllianceStationID_red1,
-
-        HALAllianceStationID_red2,
-
-        HALAllianceStationID_red3,
-
-        HALAllianceStationID_blue1,
-
-        HALAllianceStationID_blue2,
-
-
-        HALAllianceStationID_blue3,
-// ReSharper restore InconsistentNaming
-    }
-
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public struct HALJoystickAxes
-    {
-        /// unsigned short
-        public ushort count;
-
-        /// short[12]
-        [System.Runtime.InteropServices.MarshalAsAttribute(System.Runtime.InteropServices.UnmanagedType.ByValArray, SizeConst = 12, ArraySubType = System.Runtime.InteropServices.UnmanagedType.I2)]
-        public short[] axes;
-    }
-
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public struct HALJoystickPOVs
-    {
-        /// unsigned short
-        public ushort count;
-
-        /// short[12]
-        [System.Runtime.InteropServices.MarshalAsAttribute(System.Runtime.InteropServices.UnmanagedType.ByValArray, SizeConst = 12, ArraySubType = System.Runtime.InteropServices.UnmanagedType.I2)]
-        public short[] povs;
-    }
-
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential)]
-    public struct HALJoystickButtons
-    {
-        /// unsigned int
-        public uint buttons;
-
-        /// byte
-        public byte count;
-    }
-
-    [System.Runtime.InteropServices.StructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential, CharSet = System.Runtime.InteropServices.CharSet.Ansi)]
-    public struct HALJoystickDescriptor
-    {
-        /// byte
-        public byte isXbox;
-
-        /// byte
-        public byte type;
-
-        /// char[256]
-        [System.Runtime.InteropServices.MarshalAsAttribute(System.Runtime.InteropServices.UnmanagedType.ByValTStr, SizeConst = 256)]
-        public string name;
-
-        /// byte
-        public byte axisCount;
-
-        /// byte
-        public byte axisTypes;
-
-        /// byte
-        public byte buttonCount;
-
-        /// byte
-        public byte povCount;
-    }
-
     public class HAL
     {
-        //public const string "libHALAthena_shared.so" = "libHALAthena_shared.so"; 
-
         /// Return Type: void*
         ///pin: byte
         [System.Runtime.InteropServices.DllImportAttribute("libHALAthena_shared.so", EntryPoint = "getPort")]
@@ -139,7 +62,7 @@ namespace HAL_FRC
         /// Return Type: int
         ///data: HALControlWord*
         [System.Runtime.InteropServices.DllImportAttribute("libHALAthena_shared.so", EntryPoint = "HALGetControlWord")]
-        private static extern int GetControlWord(ref uint data);
+        public static extern int GetControlWord(ref uint data);
 
 
         /// Return Type: int
@@ -214,7 +137,7 @@ namespace HAL_FRC
         /// Return Type: int
         ///mode: int
         [System.Runtime.InteropServices.DllImportAttribute("libHALAthena_shared.so", EntryPoint = "HALInitialize")]
-        private static extern int HALInitialize(int mode = 0);
+        public static extern int HALInitialize(int mode = 0);
 
 
         /// Return Type: void
@@ -248,7 +171,7 @@ namespace HAL_FRC
         ///context: byte
         ///feature: char*
         [System.Runtime.InteropServices.DllImportAttribute("libHALAthena_shared.so", EntryPoint = "HALReport")]
-        private static extern uint HALReport(byte resource, byte instanceNumber, byte context = 0, [System.Runtime.InteropServices.InAttribute()] [System.Runtime.InteropServices.MarshalAsAttribute(System.Runtime.InteropServices.UnmanagedType.LPStr)] string feature = null);
+        public static extern uint HALReport(byte resource, byte instanceNumber, byte context = 0, [System.Runtime.InteropServices.InAttribute()] [System.Runtime.InteropServices.MarshalAsAttribute(System.Runtime.InteropServices.UnmanagedType.LPStr)] string feature = null);
 
 
         /// Return Type: void
@@ -269,156 +192,5 @@ namespace HAL_FRC
         /// Return Type: void
         [System.Runtime.InteropServices.DllImportAttribute("libHALAthena_shared.so", EntryPoint = "Occur")]
         public static extern void Occur();
-
-
-        //Getting Joystick Axes
-        public static short[] GetJoystickAxes(byte joystickNum)
-        {
-            var axes = new HALJoystickAxes();
-            GetJoystickAxes(joystickNum, ref axes);
-            return axes.axes;
-        }
-
-        public static uint GetJoystickButtons(byte joystickNum, ref int count)
-        {
-            HALJoystickButtons joystickButtons = new HALJoystickButtons();
-            GetJoystickButtons(joystickNum, ref joystickButtons);
-            count = joystickButtons.count;
-            return joystickButtons.buttons;
-        }
-
-        /*
-        public static HALJoystickButtons GetJoystickButtons(byte joystickNum)
-        {
-
-            Console.WriteLine("Getting Joystick Axes");
-            var buttons = new HALJoystickButtons();
-            GetJoystickButtons(joystickNum, ref buttons);
-            return buttons;
-        }
-        */
-        public static HALJoystickDescriptor GetJoystickDescriptor(byte joystickNum)
-        {
-            var descriptor = new HALJoystickDescriptor();
-            GetJoystickDescriptor(joystickNum, ref descriptor);
-            return descriptor;
-        }
-
-        //GettingJoystickPOVs
-        public static short[] GetJoystickPOVs(byte joystickNum)
-        {
-
-            var povs = new HALJoystickPOVs();
-            GetJoystickPOVs(joystickNum, ref povs);
-            return povs.povs;
-        }
-
-        public static int SetErrorData(string errors, int waitMs)
-        {
-            return SetErrorData(errors, errors.Length, waitMs);
-        }
-
-        public static void Initialize(int mode = 0)
-        {
-            var rv = HALInitialize();
-
-            //HALDigital.SetupHAL(Assembly.LoadFrom("/home/lvuser/mono/HAL-RoboRIO.dll"));
-            if (rv == 0)
-            {
-                //Throw exception saying HAL not initialized
-                throw new Exception("HAL Initialize Failed");
-            }
-        }
-
-
-        //Move to WPILib
-
-        public static uint Report(ResourceType resource, Instances instanceNumber, byte context = 0,
-            string feature = null)
-        {
-            return HALReport((byte)resource, (byte)instanceNumber, context, feature);
-        }
-
-        public static uint Report(ResourceType resource, byte instanceNumber, byte context = 0,
-            string feature = null)
-        {
-            return HALReport((byte)resource, instanceNumber, context, feature);
-        }
-
-        public static uint Report(byte resource, Instances instanceNumber, byte context = 0,
-            string feature = null)
-        {
-            return HALReport(resource, (byte)instanceNumber, context, feature);
-        }
-
-        public static uint Report(byte resource, byte instanceNumber, byte context = 0,
-            string feature = null)
-        {
-            return HALReport(resource, instanceNumber, context, feature);
-        }
-
-        /*
-        public static void CheckStatus(int status)
-        {
-            if (status < 0)
-            {
-                string message = GetHALErrorMessage(status);
-                throw new SystemException(" Code: " + status + ". " + message);
-            }
-            else if (status > 0)
-            {
-                string message = GetHALErrorMessage(status);
-                DriverStation.ReportError(message, true);
-            }
-        }
-         * */
-
-        public static HALControlWord GetControlWord()
-        {
-            //HALControlWord temp = new HALControlWord();
-            uint temp = 0;
-            GetControlWord(ref temp);
-            return new HALControlWord(temp);
-        }
-    }
-
-    public struct HALControlWord
-    {
-        private uint _wordData;
-
-        public HALControlWord(uint data)
-        {
-            _wordData = data;
-        }
-
-        public bool GetEnabled()
-        {
-            return (_wordData & (1 << 1 - 1)) != 0;
-        }
-
-        public bool GetAutonomous()
-        {
-            return (_wordData & (1 << 2 - 1)) != 0;
-        }
-
-        public bool GetTest()
-        {
-            return (_wordData & (1 << 3 - 1)) != 0;
-        }
-
-        public bool GetEStop()
-        {
-            return (_wordData & (1 << 4 - 1)) != 0;
-        }
-
-        public bool GetFMSAttached()
-        {
-            return (_wordData & (1 << 5 - 1)) != 0;
-        }
-
-        public bool GetDSAttached()
-        {
-            return (_wordData & (1 << 6 - 1)) != 0;
-        }
     }
 }

--- a/HAL-RoboRIO/HALAccelerometer.cs
+++ b/HAL-RoboRIO/HALAccelerometer.cs
@@ -1,17 +1,7 @@
-﻿namespace HAL_FRC
+﻿using HAL_Base;
+
+namespace HAL_RoboRIO
 {
-    public enum AccelerometerRange
-    {
-        /// kRange_2G -> 0
-        Range_2G = 0,
-
-        /// kRange_4G -> 1
-        Range_4G = 1,
-
-        /// kRange_8G -> 2
-        Range_8G = 2,
-    }
-
     public class HALAccelerometer
     {
         /// Return Type: void

--- a/HAL-RoboRIO/HALAnalog.cs
+++ b/HAL-RoboRIO/HALAnalog.cs
@@ -1,20 +1,7 @@
-﻿namespace HAL_FRC
+﻿using HAL_Base;
+
+namespace HAL_RoboRIO
 {
-    public enum AnalogTriggerType
-    {
-        /// kInWindow -> 0
-        InWindow = 0,
-
-        /// kState -> 1
-        State = 1,
-
-        /// kRisingPulse -> 2
-        RisingPulse = 2,
-
-        /// kFallingPulse -> 3
-        FallingPulse = 3,
-    }
-
     public class HALAnalog
     {
         /// Return Type: void*

--- a/HAL-RoboRIO/HALCANTalon.cs
+++ b/HAL-RoboRIO/HALCANTalon.cs
@@ -1,22 +1,7 @@
-﻿
-namespace HAL_FRC
+﻿using HAL_Base;
+
+namespace HAL_RoboRIO
 {
-    public enum CTR_Code
-    {
-        CTR_OKAY,
-
-        CTR_RxTimeout,
-
-        CTR_TxTimeout,
-
-        CTR_InvalidParamValue,
-
-        CTR_UnexpectedArbId,
-
-        CTR_TxFailed,
-
-        CTR_SigNotUpdated,
-    }
     public class HALCANTalon
     {
         /// Return Type: void*

--- a/HAL-RoboRIO/HALCompressor.cs
+++ b/HAL-RoboRIO/HALCompressor.cs
@@ -1,4 +1,4 @@
-﻿namespace HAL_FRC
+﻿namespace HAL_RoboRIO
 {
     public class HALCompressor
     {

--- a/HAL-RoboRIO/HALDigital.cs
+++ b/HAL-RoboRIO/HALDigital.cs
@@ -2,53 +2,13 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Reflection;
+using HAL_Base;
 
-namespace HAL_FRC
+namespace HAL_RoboRIO
 {
-    public enum Mode
-    {
-        /// kTwoPulse -> 0
-        TwoPulse = 0,
-
-        /// kSemiperiod -> 1
-        Semiperiod = 1,
-
-        /// kPulseLength -> 2
-        PulseLength = 2,
-
-        /// kExternalDirection -> 3
-        ExternalDirection = 3,
-    }
 
     public class HALDigital
     {
-        /*
-         * 
-         * Reflection stuff. I know that this works. It will just require a major project refactoring to implement. But this will be a much better way, and will 
-         * work with the simulator much better, and not require the import hacks reuqired currently.
-        private delegate IntPtr RetIntPtrPerIntPtrStatus(IntPtr intptr, ref int status);
-
-
-        private static RetIntPtrPerIntPtrStatus initDigitalPort;
-
-
-        internal static void SetupHAL(Assembly assembly)
-        {
-            Type type;
-
-            type = assembly.GetType("HAL_FRC.HALDigital");
-
-            initDigitalPort = (RetIntPtrPerIntPtrStatus)Delegate.CreateDelegate(typeof(RetIntPtrPerIntPtrStatus), type.GetMethod("initializeDigitalPort"));
-        }
-
-        public static IntPtr InitializeDigitalPort(IntPtr portPointer, ref int status)
-        {
-            return initDigitalPort(portPointer, ref status);
-        }
-         * */
-         
-
-
         /// Return Type: void*
         ///port_pointer: void*
         ///status: int*

--- a/HAL-RoboRIO/HALInterrupts.cs
+++ b/HAL-RoboRIO/HALInterrupts.cs
@@ -1,11 +1,8 @@
-﻿
-namespace HAL_FRC
-{
-    /// Return Type: void
-    ///interruptAssertedMask: unsigned int
-    ///param: void*
-    public delegate void InterruptHandlerFunctionHAL(uint interruptAssertedMask, System.IntPtr param);
+﻿using HAL_Base;
 
+
+namespace HAL_RoboRIO
+{
     public class HALInterrupts
     {
         /// Return Type: void*

--- a/HAL-RoboRIO/HALNotifier.cs
+++ b/HAL-RoboRIO/HALNotifier.cs
@@ -1,11 +1,7 @@
-﻿
-namespace HAL_FRC
-{
-    /// Return Type: void
-    ///param0: unsigned int
-    ///param1: void*
-    public delegate void NotifierDelegate(uint param0, System.IntPtr param1);
+﻿using HAL_Base;
 
+namespace HAL_RoboRIO
+{
     public class HALNotifier
     {
         /// Return Type: void*

--- a/HAL-RoboRIO/HALPDP.cs
+++ b/HAL-RoboRIO/HALPDP.cs
@@ -1,4 +1,4 @@
-﻿namespace HAL_FRC
+﻿namespace HAL_RoboRIO
 {
     public class HALPDP
     {

--- a/HAL-RoboRIO/HALPower.cs
+++ b/HAL-RoboRIO/HALPower.cs
@@ -1,4 +1,4 @@
-﻿namespace HAL_FRC
+﻿namespace HAL_RoboRIO
 {
     public class HALPower
     {

--- a/HAL-RoboRIO/HALSemaphore.cs
+++ b/HAL-RoboRIO/HALSemaphore.cs
@@ -1,6 +1,6 @@
 ﻿using System.Runtime.InteropServices;
 
-namespace HAL_FRC
+namespace HAL_RoboRIO
 {
     public class HALSemaphore
     {

--- a/HAL-RoboRIO/HALSerialPort.cs
+++ b/HAL-RoboRIO/HALSerialPort.cs
@@ -1,4 +1,4 @@
-﻿namespace HAL_FRC
+﻿namespace HAL_RoboRIO
 {
     public class HALSerialPort
     {

--- a/HAL-RoboRIO/HALSolenoid.cs
+++ b/HAL-RoboRIO/HALSolenoid.cs
@@ -1,4 +1,4 @@
-﻿namespace HAL_FRC
+﻿namespace HAL_RoboRIO
 {
     public class HALSolenoid
     {
@@ -62,3 +62,4 @@
         public static extern void clearAllPCMStickyFaults_sol(System.IntPtr solenoidPortPointer, ref int status);
     }
 }
+

--- a/HAL-RoboRIO/HALUtilities.cs
+++ b/HAL-RoboRIO/HALUtilities.cs
@@ -1,5 +1,5 @@
 ﻿
-namespace HAL_FRC
+namespace HAL_RoboRIO
 {
     public class HALUtilities
     {
@@ -20,6 +20,5 @@ namespace HAL_FRC
         [System.Runtime.InteropServices.DllImportAttribute("libHALAthena_shared.so", EntryPoint = "delaySeconds")]
         public static extern void delaySeconds(double s);
 
-        public static int PARAMETER_OUT_OF_RANGE = -1028;
     }
 }

--- a/WPILib/AnalogInput.cs
+++ b/WPILib/AnalogInput.cs
@@ -3,7 +3,7 @@
 using System;
 using WPILib.Interfaces;
 using WPILib.Util;
-using HAL_FRC;
+using HAL_Base;
 
 namespace WPILib
 {
@@ -34,7 +34,7 @@ namespace WPILib
 
             IntPtr portPointer = HAL.GetPort((byte)channel);
             int status = 0;
-            _port = HALAnalog.initializeAnalogInputPort(portPointer, ref status);
+            _port = HALAnalog.InitializeAnalogInputPort(portPointer, ref status);
             HAL.Report(ResourceType.kResourceType_AnalogChannel, (byte)channel);
         }
 
@@ -48,42 +48,42 @@ namespace WPILib
         public int GetValue()
         {
             int status = 0;
-            int value = HALAnalog.getAnalogValue(_port, ref status);
+            int value = HALAnalog.GetAnalogValue(_port, ref status);
             return value;
         }
 
         public int GetAverageValue()
         {
             int status = 0;
-            int value = HALAnalog.getAnalogAverageValue(_port, ref status);
+            int value = HALAnalog.GetAnalogAverageValue(_port, ref status);
             return value;
         }
 
         public double GetVoltage()
         {
             int status = 0;
-            double value = HALAnalog.getAnalogVoltage(_port, ref status);
+            double value = HALAnalog.GetAnalogVoltage(_port, ref status);
             return value;
         }
 
         public double GetAverageVoltage()
         {
             int status = 0;
-            double value = HALAnalog.getAnalogAverageVoltage(_port, ref status);
+            double value = HALAnalog.GetAnalogAverageVoltage(_port, ref status);
             return value;
         }
 
         public long GetLSBWeight()
         {
             int status = 0;
-            long value = HALAnalog.getAnalogLSBWeight(_port, ref status);
+            long value = HALAnalog.GetAnalogLSBWeight(_port, ref status);
             return value;
         }
 
         public int GetOffset()
         {
             int status = 0;
-            int value = HALAnalog.getAnalogOffset(_port, ref status);
+            int value = HALAnalog.GetAnalogOffset(_port, ref status);
             return value;
         }
 
@@ -95,26 +95,26 @@ namespace WPILib
         public void SetAverageBits(int bits)
         {
             int status = 0;
-            HALAnalog.setAnalogAverageBits(_port, (uint)bits, ref status);
+            HALAnalog.SetAnalogAverageBits(_port, (uint)bits, ref status);
         }
 
         public int GetAverageBits()
         {
             int status = 0;
-            uint value = HALAnalog.getAnalogAverageBits(_port, ref status);
+            uint value = HALAnalog.GetAnalogAverageBits(_port, ref status);
             return (int)value;
         }
 
         public void SetOversampleBits(int bits)
         {
             int status = 0;
-            HALAnalog.setAnalogOversampleBits(_port, (uint)bits, ref status);
+            HALAnalog.SetAnalogOversampleBits(_port, (uint)bits, ref status);
         }
 
         public int GetOversampleBits()
         {
             int status = 0;
-            uint value = HALAnalog.getAnalogOversampleBits(_port, ref status);
+            uint value = HALAnalog.GetAnalogOversampleBits(_port, ref status);
             return (int)value;
         }
 
@@ -126,7 +126,7 @@ namespace WPILib
             }
             _accumulatorOffset = 0;
             int status = 0;
-            HALAnalog.initAccumulator(_port, ref status);
+            HALAnalog.InitAccumulator(_port, ref status);
         }
 
         public void SetAccumulatorInitialValue(long initialValue)
@@ -137,7 +137,7 @@ namespace WPILib
         public void ResetAccumulator()
         {
             int status = 0;
-            HALAnalog.resetAccumulator(_port, ref status);
+            HALAnalog.ResetAccumulator(_port, ref status);
 
             double sampleTime = 1.0 / GetGlobalSampleRate();
             double overSamples = 1 << GetOversampleBits();
@@ -148,20 +148,20 @@ namespace WPILib
         public void SetAccumulatorDeadband(int deadband)
         {
             int status = 0;
-            HALAnalog.setAccumulatorDeadband(_port, deadband, ref status);
+            HALAnalog.SetAccumulatorDeadband(_port, deadband, ref status);
         }
 
         public long GetAccumulatorValue()
         {
             int status = 0;
-            long value = HALAnalog.getAccumulatorValue(_port, ref status);
+            long value = HALAnalog.GetAccumulatorValue(_port, ref status);
             return value + _accumulatorOffset;
         }
 
         public long GetAccumulatorCount()
         {
             int status = 0;
-            long value = HALAnalog.getAccumulatorCount(_port, ref status);
+            long value = HALAnalog.GetAccumulatorCount(_port, ref status);
             return value;
         }
 
@@ -176,7 +176,7 @@ namespace WPILib
             uint count = 0;
             int value = 0;
             int status = 0;
-            HALAnalog.getAccumulatorOutput(_port, ref value, ref count, ref status);
+            HALAnalog.GetAccumulatorOutput(_port, ref value, ref count, ref status);
             result.m_value = value + _accumulatorOffset;
             result.m_count = count;
         }
@@ -197,13 +197,13 @@ namespace WPILib
         public static void SetGlobalSampleRate(double samplesPerSecond)
         {
             int status = 0;
-            HALAnalog.setAnalogSampleRate(samplesPerSecond, ref status);
+            HALAnalog.SetAnalogSampleRate(samplesPerSecond, ref status);
         }
 
         public static double GetGlobalSampleRate()
         {
             int status = 0;
-            double value = HALAnalog.getAnalogSampleRate(ref status);
+            double value = HALAnalog.GetAnalogSampleRate(ref status);
             return value;
         }
 

--- a/WPILib/AnalogTrigger.cs
+++ b/WPILib/AnalogTrigger.cs
@@ -2,7 +2,7 @@
 
 using System;
 using WPILib.Util;
-using HAL_FRC;
+using HAL_Base;
 
 namespace WPILib
 {
@@ -17,7 +17,7 @@ namespace WPILib
             int status = 0;
             uint index = 0;
 
-            m_port = HALAnalog.initializeAnalogTrigger(portPointer, ref index, ref status);
+            m_port = HALAnalog.InitializeAnalogTrigger(portPointer, ref index, ref status);
             m_index = (int)index;
 
             HAL.Report(ResourceType.kResourceType_AnalogTrigger, (byte)channel);
@@ -38,7 +38,7 @@ namespace WPILib
         public void Free()
         {
             int status = 0;
-            HALAnalog.cleanAnalogTrigger(m_port, ref status);
+            HALAnalog.CleanAnalogTrigger(m_port, ref status);
             m_port = IntPtr.Zero;
         }
 
@@ -47,7 +47,7 @@ namespace WPILib
             if (lower > upper)
                 throw new BoundaryException("Lower bound is greater than upper");
             int status = 0;
-            HALAnalog.setAnalogTriggerLimitsRaw(m_port, lower, upper, ref status);
+            HALAnalog.SetAnalogTriggerLimitsRaw(m_port, lower, upper, ref status);
         }
 
         public void SetLimitsVoltage(double lower, double upper)
@@ -55,13 +55,13 @@ namespace WPILib
             if (lower > upper)
                 throw new BoundaryException("Lower bound is greater than upper");
             int status = 0;
-            HALAnalog.setAnalogTriggerLimitsVoltage(m_port, lower, upper, ref status);
+            HALAnalog.SetAnalogTriggerLimitsVoltage(m_port, lower, upper, ref status);
         }
 
         public void SetAveraged(bool useAveragedValue)
         {
             int status = 0;
-            HALAnalog.setAnalogTriggerFiltered(m_port, useAveragedValue, ref status);
+            HALAnalog.SetAnalogTriggerFiltered(m_port, useAveragedValue, ref status);
         }
 
         public int GetIndex()
@@ -72,14 +72,14 @@ namespace WPILib
         public bool GetInWindow()
         {
             int status = 0;
-            bool value = HALAnalog.getAnalogTriggerInWindow(m_port, ref status);
+            bool value = HALAnalog.GetAnalogTriggerInWindow(m_port, ref status);
             return value;
         }
 
         public bool GetTriggerState()
         {
             int status = 0;
-            bool value = HALAnalog.getAnalogTriggerTriggerState(m_port, ref status);
+            bool value = HALAnalog.GetAnalogTriggerTriggerState(m_port, ref status);
             return value;
         }
 

--- a/WPILib/AnalogTriggerOutput.cs
+++ b/WPILib/AnalogTriggerOutput.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using HAL_FRC;
+using HAL_Base;
 using WPILib.Util;
 
 namespace WPILib
@@ -30,7 +30,7 @@ namespace WPILib
         public bool Get()
         {
             int status = 0;
-            bool value = HALAnalog.getAnalogTriggerOutput(m_trigger.m_port, m_outputType, ref status);
+            bool value = HALAnalog.GetAnalogTriggerOutput(m_trigger.m_port, m_outputType, ref status);
             return value;
         }
 

--- a/WPILib/ControllerPower.cs
+++ b/WPILib/ControllerPower.cs
@@ -1,4 +1,4 @@
-﻿using HAL_FRC;
+﻿using HAL_Base;
 
 namespace WPILib
 {
@@ -7,98 +7,98 @@ namespace WPILib
         public static double GetInputVoltage()
         {
             int status = 0;
-            double retVal = HALPower.getVinVoltage(ref status);
+            double retVal = HALPower.GetVinVoltage(ref status);
             return retVal;
         }
 
         public static double GetInputCurrrent()
         {
             int status = 0;
-            double retVal = HALPower.getVinCurrent(ref status);
+            double retVal = HALPower.GetVinCurrent(ref status);
             return retVal;
         }
 
         public static double GetVoltage3V3()
         {
             int status = 0;
-            double retVal = HALPower.getUserVoltage3V3(ref status);
+            double retVal = HALPower.GetUserVoltage3V3(ref status);
             return retVal;
         }
 
         public static double GetCurrent3V3()
         {
             int status = 0;
-            double retVal = HALPower.getUserCurrent3V3(ref status);
+            double retVal = HALPower.GetUserCurrent3V3(ref status);
             return retVal;
         }
 
         public static bool GetEnabled3V3()
         {
             int status = 0;
-            bool retVal = HALPower.getUserActive3V3(ref status);
+            bool retVal = HALPower.GetUserActive3V3(ref status);
             return retVal;
         }
 
         public static int GetFaultCount3V3()
         {
             int status = 0;
-            int retVal = HALPower.getUserCurrentFaults3V3(ref status);
+            int retVal = HALPower.GetUserCurrentFaults3V3(ref status);
             return retVal;
         }
 
         public static double GetVoltage5V()
         {
             int status = 0;
-            double retVal = HALPower.getUserVoltage5V(ref status);
+            double retVal = HALPower.GetUserVoltage5V(ref status);
             return retVal;
         }
 
         public static double GetCurrent5V()
         {
             int status = 0;
-            double retVal = HALPower.getUserCurrent5V(ref status);
+            double retVal = HALPower.GetUserCurrent5V(ref status);
             return retVal;
         }
 
         public static bool GetEnabled5V()
         {
             int status = 0;
-            bool retVal = HALPower.getUserActive5V(ref status);
+            bool retVal = HALPower.GetUserActive5V(ref status);
             return retVal;
         }
 
         public static int GetFaultCount5V()
         {
             int status = 0;
-            int retVal = HALPower.getUserCurrentFaults5V(ref status);
+            int retVal = HALPower.GetUserCurrentFaults5V(ref status);
             return retVal;
         }
 
         public static double GetVoltage6V()
         {
             int status = 0;
-            double retVal = HALPower.getUserVoltage6V(ref status);
+            double retVal = HALPower.GetUserVoltage6V(ref status);
             return retVal;
         }
 
         public static double GetCurrent6V()
         {
             int status = 0;
-            double retVal = HALPower.getUserCurrent6V(ref status);
+            double retVal = HALPower.GetUserCurrent6V(ref status);
             return retVal;
         }
 
         public static bool GetEnabled6V()
         {
             int status = 0;
-            bool retVal = HALPower.getUserActive6V(ref status);
+            bool retVal = HALPower.GetUserActive6V(ref status);
             return retVal;
         }
 
         public static int GetFaultCount6V()
         {
             int status = 0;
-            int retVal = HALPower.getUserCurrentFaults6V(ref status);
+            int retVal = HALPower.GetUserCurrentFaults6V(ref status);
             return retVal;
         }
 

--- a/WPILib/Counter.cs
+++ b/WPILib/Counter.cs
@@ -3,7 +3,7 @@
 using System;
 using WPILib.Interfaces;
 using WPILib.Util;
-using HAL_FRC;
+using HAL_Base;
 
 namespace WPILib
 {
@@ -21,7 +21,7 @@ namespace WPILib
         private void InitCounter(Mode mode)
         {
             int status = 0;
-            m_counter = HALDigital.initializeCounter(mode, ref m_index, ref status);
+            m_counter = HALDigital.InitializeCounter(mode, ref m_index, ref status);
 
             m_allocatedUpSource = false;
             m_allocatedDownSource = false;
@@ -70,12 +70,12 @@ namespace WPILib
             if (encodingType == EncodingType.K1X)
             {
                 SetUpSourceEdge(true, false);
-                HALDigital.setCounterAverageSize(m_counter, 1, ref status);
+                HALDigital.SetCounterAverageSize(m_counter, 1, ref status);
             }
             else
             {
                 SetDownSourceEdge(true, true);
-                HALDigital.setCounterAverageSize(m_counter, 2, ref status);
+                HALDigital.SetCounterAverageSize(m_counter, 2, ref status);
             }
 
             SetDownSourceEdge(inverted, true);
@@ -99,7 +99,7 @@ namespace WPILib
             ClearDownSource();
 
             int status = 0;
-            HALDigital.freeCounter(m_counter, ref status);
+            HALDigital.FreeCounter(m_counter, ref status);
 
             m_upSource = null;
             m_downSource = null;
@@ -125,7 +125,7 @@ namespace WPILib
             }
             m_upSource = source;
             int status = 0;
-            HALDigital.setCounterUpSource(m_counter, (uint)source.GetChannelForRouting(), source.GetAnalogTriggerForRouting(), ref status);
+            HALDigital.SetCounterUpSource(m_counter, (uint)source.GetChannelForRouting(), source.GetAnalogTriggerForRouting(), ref status);
         }
 
         public void SetUpSource(AnalogTrigger analogTrigger, AnalogTriggerType triggerType)
@@ -143,7 +143,7 @@ namespace WPILib
             if (m_upSource == null)
                 throw new SystemException("Up Source must be set before setting the edge!");
             int status = 0;
-            HALDigital.setCounterUpSourceEdge(m_counter, risingEdge, fallingEdge, ref status);
+            HALDigital.SetCounterUpSourceEdge(m_counter, risingEdge, fallingEdge, ref status);
         }
 
         public void ClearUpSource()
@@ -156,7 +156,7 @@ namespace WPILib
             m_upSource = null;
 
             int status = 0;
-            HALDigital.clearCounterUpSource(m_counter, ref status);
+            HALDigital.ClearCounterUpSource(m_counter, ref status);
         }
 
 
@@ -175,7 +175,7 @@ namespace WPILib
             }
             m_downSource = source;
             int status = 0;
-            HALDigital.setCounterDownSource(m_counter, (uint)source.GetChannelForRouting(), source.GetAnalogTriggerForRouting(), ref status);
+            HALDigital.SetCounterDownSource(m_counter, (uint)source.GetChannelForRouting(), source.GetAnalogTriggerForRouting(), ref status);
         }
 
         public void SetDownSource(AnalogTrigger analogTrigger, AnalogTriggerType triggerType)
@@ -193,7 +193,7 @@ namespace WPILib
             if (m_downSource == null)
                 throw new SystemException("Up Source must be set before setting the edge!");
             int status = 0;
-            HALDigital.setCounterDownSourceEdge(m_counter, risingEdge, fallingEdge, ref status);
+            HALDigital.SetCounterDownSourceEdge(m_counter, risingEdge, fallingEdge, ref status);
         }
 
         public void ClearDownSource()
@@ -206,31 +206,31 @@ namespace WPILib
             m_downSource = null;
 
             int status = 0;
-            HALDigital.clearCounterDownSource(m_counter, ref status);
+            HALDigital.ClearCounterDownSource(m_counter, ref status);
         }
 
         public void SetUpDownCounterMode()
         {
             int status = 0;
-            HALDigital.setCounterUpDownMode(m_counter, ref status);
+            HALDigital.SetCounterUpDownMode(m_counter, ref status);
         }
 
         public void SetExternalDirectionMode()
         {
             int status = 0;
-            HALDigital.setCounterExternalDirectionMode(m_counter, ref status);
+            HALDigital.SetCounterExternalDirectionMode(m_counter, ref status);
         }
 
         public void SetSemiPeriodMode(bool highSemiPeriod)
         {
             int status = 0;
-            HALDigital.setCounterSemiPeriodMode(m_counter, highSemiPeriod, ref status);
+            HALDigital.SetCounterSemiPeriodMode(m_counter, highSemiPeriod, ref status);
         }
 
         public int Get()
         {
             int status = 0;
-            int value = HALDigital.getCounter(m_counter, ref status);
+            int value = HALDigital.GetCounter(m_counter, ref status);
             return value;
         }
 
@@ -242,45 +242,45 @@ namespace WPILib
         public void Reset()
         {
             int status = 0;
-            HALDigital.resetCounter(m_counter, ref status);
+            HALDigital.ResetCounter(m_counter, ref status);
         }
 
         public void SetMaxPeriod(double maxPeriod)
         {
             int status = 0;
-            HALDigital.setCounterMaxPeriod(m_counter, maxPeriod, ref status);
+            HALDigital.SetCounterMaxPeriod(m_counter, maxPeriod, ref status);
         }
 
         public void SetUpdateWhenEmpty(bool enabled)
         {
             int status = 0;
-            HALDigital.setCounterUpdateWhenEmpty(m_counter, enabled, ref status);
+            HALDigital.SetCounterUpdateWhenEmpty(m_counter, enabled, ref status);
         }
 
         public bool GetStopped()
         {
             int status = 0;
-            bool value = HALDigital.getCounterStopped(m_counter, ref status);
+            bool value = HALDigital.GetCounterStopped(m_counter, ref status);
             return value;
         }
 
         public bool GetDirection()
         {
             int status = 0;
-            bool value = HALDigital.getCounterDirection(m_counter, ref status);
+            bool value = HALDigital.GetCounterDirection(m_counter, ref status);
             return value;
         }
 
         public void SetReverseDirection(bool reverseDirection)
         {
             int status = 0;
-            HALDigital.setCounterReverseDirection(m_counter, reverseDirection, ref status);
+            HALDigital.SetCounterReverseDirection(m_counter, reverseDirection, ref status);
         }
 
         public double GetPeriod()
         {
             int status = 0;
-            double value = HALDigital.getCounterPeriod(m_counter, ref status);
+            double value = HALDigital.GetCounterPeriod(m_counter, ref status);
             return value;
         }
 
@@ -292,7 +292,7 @@ namespace WPILib
         public void SetSamplesToAverage(int samplesToAverage)
         {
             int status = 0;
-            HALDigital.setCounterSamplesToAverage(m_counter, samplesToAverage, ref status);
+            HALDigital.SetCounterSamplesToAverage(m_counter, samplesToAverage, ref status);
             if (status == HALUtilities.PARAMETER_OUT_OF_RANGE)
             {
                 throw new BoundaryException(BoundaryException.GetMessage(samplesToAverage, 1, 127));
@@ -302,7 +302,7 @@ namespace WPILib
         public int GetSamplesToAverage()
         {
             int status = 0;
-            int value = HALDigital.getCounterSamplesToAverage(m_counter, ref status);
+            int value = HALDigital.GetCounterSamplesToAverage(m_counter, ref status);
             return value;
         }
 

--- a/WPILib/DigitalInput.cs
+++ b/WPILib/DigitalInput.cs
@@ -1,4 +1,4 @@
-﻿using HAL_FRC;
+﻿using HAL_Base;
 
 namespace WPILib
 {
@@ -14,7 +14,7 @@ namespace WPILib
         public bool Get()
         {
             int status = 0;
-            bool value = HALDigital.getDIO(m_port, ref status);
+            bool value = HALDigital.GetDIO(m_port, ref status);
             return value;
         }
 

--- a/WPILib/DigitalOutput.cs
+++ b/WPILib/DigitalOutput.cs
@@ -1,13 +1,13 @@
 ﻿
 
 using System;
-using HAL_FRC;
+using HAL_Base;
 
 namespace WPILib
 {
     public class DigitalOutput : DigitalSource
     {
-        private IntPtr _pwmGenerator = IntPtr.Zero;
+        private IntPtr m_pwmGenerator = IntPtr.Zero;
 
         public DigitalOutput(int channel)
         {
@@ -18,7 +18,7 @@ namespace WPILib
 
         public override void Free()
         {
-            if (_pwmGenerator != IntPtr.Zero)
+            if (m_pwmGenerator != IntPtr.Zero)
             {
                 DisablePWM();
             }
@@ -29,7 +29,7 @@ namespace WPILib
         public void Set(bool value)
         {
             int status = 0;
-            HALDigital.setDIO(m_port, (short)(value ? 0 : 1), ref status);
+            HALDigital.SetDIO(m_port, (short)(value ? 0 : 1), ref status);
         }
 
         public int GetChannel()
@@ -40,48 +40,48 @@ namespace WPILib
         public void Pulse(int channel, float pulseLength)
         {
             int status = 0;
-            HALDigital.pulse(m_port, pulseLength, ref status);
+            HALDigital.Pulse(m_port, pulseLength, ref status);
         }
 
         public bool IsPulsing()
         {
             int status = 0;
-            bool value = HALDigital.isPulsing(m_port, ref status);
+            bool value = HALDigital.IsPulsing(m_port, ref status);
             return value;
         }
 
         public void SetPWMRate(double rate)
         {
             int status = 0;
-            HALDigital.setPWMRate(rate, ref status);
+            HALDigital.SetPWMRate(rate, ref status);
         }
 
         public void EnablePWM(double initialDutyCycle)
         {
-            if (_pwmGenerator != IntPtr.Zero)
+            if (m_pwmGenerator != IntPtr.Zero)
                 return;
             int status = 0;
-            _pwmGenerator = HALDigital.allocatePWM(ref status);
-            HALDigital.setPWMDutyCycle(_pwmGenerator, initialDutyCycle, ref status);
-            HALDigital.setPWMOutputChannel(_pwmGenerator, (uint)m_channel, ref status);
+            m_pwmGenerator = HALDigital.AllocatePWM(ref status);
+            HALDigital.SetPWMDutyCycle(m_pwmGenerator, initialDutyCycle, ref status);
+            HALDigital.SetPWMOutputChannel(m_pwmGenerator, (uint)m_channel, ref status);
         }
 
         public void DisablePWM()
         {
-            if (_pwmGenerator == IntPtr.Zero)
+            if (m_pwmGenerator == IntPtr.Zero)
                 return;
             int status = 0;
-            HALDigital.setPWMOutputChannel(_pwmGenerator, (uint)DigitalChannels, ref status);
-            HALDigital.freePWM(_pwmGenerator, ref status);
-            _pwmGenerator = IntPtr.Zero;
+            HALDigital.SetPWMOutputChannel(m_pwmGenerator, (uint)DigitalChannels, ref status);
+            HALDigital.FreePWM(m_pwmGenerator, ref status);
+            m_pwmGenerator = IntPtr.Zero;
         }
 
         public void UpdateDutyCycle(double dutyCycle)
         {
-            if (_pwmGenerator == IntPtr.Zero)
+            if (m_pwmGenerator == IntPtr.Zero)
                 return;
             int status = 0;
-            HALDigital.setPWMDutyCycle(_pwmGenerator, dutyCycle, ref status);
+            HALDigital.SetPWMDutyCycle(m_pwmGenerator, dutyCycle, ref status);
         }
     }
 }

--- a/WPILib/DigitalSource.cs
+++ b/WPILib/DigitalSource.cs
@@ -2,7 +2,7 @@
 
 using System;
 using WPILib.Util;
-using HAL_FRC;
+using HAL_Base;
 
 namespace WPILib
 {
@@ -29,15 +29,15 @@ namespace WPILib
 
             IntPtr portPointer = HAL.GetPort((byte)channel);
             int status = 0;
-            m_port = HALDigital.initializeDigitalPort(portPointer, ref status);
-            HALDigital.allocateDIO(m_port, input, ref status);
+            m_port = HALDigital.InitializeDigitalPort(portPointer, ref status);
+            HALDigital.AllocateDIO(m_port, input, ref status);
         }
 
         public override void Free()
         {
             s_channels.Free(m_channel);
             int status = 0;
-            HALDigital.freeDIO(m_port, ref status);
+            HALDigital.FreeDIO(m_port, ref status);
             m_channel = 0;
         }
 

--- a/WPILib/DriverStation.cs
+++ b/WPILib/DriverStation.cs
@@ -5,7 +5,7 @@ using System.IO;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Threading;
-using HAL_FRC;
+using HAL_Base;
 
 namespace WPILib
 {
@@ -69,14 +69,14 @@ namespace WPILib
             }
             
 
-            m_packetDataAvailableMultiWait = HALSemaphore.initializeMultiWait();
-            m_newControlData = HALSemaphore.initializeSemaphore(0);
+            m_packetDataAvailableMultiWait = HALSemaphore.InitializeMultiWait();
+            m_newControlData = HALSemaphore.InitializeSemaphore(0);
 
-            m_waitForDataSem = HALSemaphore.initializeMultiWait();
-            m_waitForDataMutex = HALSemaphore.initializeMutexNormal();
+            m_waitForDataSem = HALSemaphore.InitializeMultiWait();
+            m_waitForDataMutex = HALSemaphore.InitializeMutexNormal();
 
 
-            m_packetDataAvailableMutex = HALSemaphore.initializeMutexNormal();
+            m_packetDataAvailableMutex = HALSemaphore.InitializeMutexNormal();
             HAL.SetNewDataSem(m_packetDataAvailableMultiWait);
 
 
@@ -98,9 +98,9 @@ namespace WPILib
             int safetyCounter = 0;
             while (m_threadKeepAlive)
             {
-                HALSemaphore.takeMultiWait(m_packetDataAvailableMultiWait, m_packetDataAvailableMutex, 0);
+                HALSemaphore.TakeMultiWait(m_packetDataAvailableMultiWait, m_packetDataAvailableMutex, 0);
                 GetData();
-                HALSemaphore.giveMultiWait(m_waitForDataSem);
+                HALSemaphore.GiveMultiWait(m_waitForDataSem);
                 if (++safetyCounter >= 4)
                 {
                     MotorSafetyHelper.CheckMotors();
@@ -121,7 +121,7 @@ namespace WPILib
 
         public void WaitForData(long timeout = 0)
         {
-            HALSemaphore.takeMultiWait(m_waitForDataSem, m_waitForDataMutex, -1);
+            HALSemaphore.TakeMultiWait(m_waitForDataSem, m_waitForDataMutex, -1);
         }
 
         protected void GetData()
@@ -132,13 +132,13 @@ namespace WPILib
                 HAL.GetJoystickPOVs(stick, ref m_joystickPOVs[stick]);
                 HAL.GetJoystickButtons(stick, ref m_joystickButtons[stick]);
             }
-            HALSemaphore.giveSemaphore(m_newControlData);
+            HALSemaphore.GiveSemaphore(m_newControlData);
         }
 
         public double GetBatteryVoltage()
         {
             int status = 0;
-            return HALPower.getVinVoltage(ref status);
+            return HALPower.GetVinVoltage(ref status);
         }
 
         private void ReportJoystickUnpluggedError(String message)
@@ -396,7 +396,7 @@ namespace WPILib
             //bool result = m_newControlData;
             //m_newControlData = false;
             //return result;
-            return HALSemaphore.tryTakeSemaphore(m_newControlData) == 0;
+            return HALSemaphore.TryTakeSemaphore(m_newControlData) == 0;
             /*
             lock (_mutex)
             {

--- a/WPILib/Encoder.cs
+++ b/WPILib/Encoder.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using WPILib.Interfaces;
 using WPILib.Util;
-using HAL_FRC;
+using HAL_Base;
 
 namespace WPILib
 {
@@ -37,7 +37,7 @@ namespace WPILib
                 case EncodingType.K4X:
                     m_encodingScale = 4;
                     int status = 0;
-                    m_encoder = HALDigital.initializeEncoder(m_aSource.GetModuleForRouting(),
+                    m_encoder = HALDigital.InitializeEncoder(m_aSource.GetModuleForRouting(),
                         (uint)m_aSource.GetChannelForRouting(),
                         m_aSource.GetAnalogTriggerForRouting(), m_bSource.GetModuleForRouting(),
                         (uint)m_bSource.GetChannelForRouting(),
@@ -208,7 +208,7 @@ namespace WPILib
             else
             {
                 int status = 0;
-                HALDigital.freeCounter(m_encoder, ref status);
+                HALDigital.FreeCounter(m_encoder, ref status);
             }
         }
 
@@ -222,7 +222,7 @@ namespace WPILib
             else
             {
                 int status = 0;
-                value = HALDigital.getEncoder(m_encoder, ref status);
+                value = HALDigital.GetEncoder(m_encoder, ref status);
             }
             return value;
         }
@@ -239,7 +239,7 @@ namespace WPILib
             else
             {
                 int status = 0;
-                HALDigital.resetEncoder(m_encoder, ref status);
+                HALDigital.ResetEncoder(m_encoder, ref status);
             }
         }
 
@@ -253,7 +253,7 @@ namespace WPILib
             else
             {
                 int status = 0;
-                measuredPeriod = HALDigital.getEncoderPeriod(m_encoder, ref status);
+                measuredPeriod = HALDigital.GetEncoderPeriod(m_encoder, ref status);
             }
             return measuredPeriod;
         }
@@ -267,7 +267,7 @@ namespace WPILib
             else
             {
                 int status = 0;
-                HALDigital.setEncoderMaxPeriod(m_encoder, maxPeriod, ref status);
+                HALDigital.SetEncoderMaxPeriod(m_encoder, maxPeriod, ref status);
             }
         }
 
@@ -280,7 +280,7 @@ namespace WPILib
             else
             {
                 int status = 0;
-                bool value = HALDigital.getEncoderStopped(m_encoder, ref status);
+                bool value = HALDigital.GetEncoderStopped(m_encoder, ref status);
                 return value;
             }
         }
@@ -294,7 +294,7 @@ namespace WPILib
             else
             {
                 int status = 0;
-                bool value = HALDigital.getEncoderDirection(m_encoder, ref status);
+                bool value = HALDigital.GetEncoderDirection(m_encoder, ref status);
                 return value;
             }
         }
@@ -343,7 +343,7 @@ namespace WPILib
             else
             {
                 int status = 0;
-                HALDigital.setEncoderReverseDirection(m_encoder, reverseDirection, ref status);
+                HALDigital.SetEncoderReverseDirection(m_encoder, reverseDirection, ref status);
             }
         }
 
@@ -353,7 +353,7 @@ namespace WPILib
             {
                 case EncodingType.K4X:
                     int status = 0;
-                    HALDigital.setEncoderSamplesToAverage(m_encoder, (uint) samplesToAverage, ref status);
+                    HALDigital.SetEncoderSamplesToAverage(m_encoder, (uint) samplesToAverage, ref status);
                     if (status == HALUtilities.PARAMETER_OUT_OF_RANGE)
                     {
                         throw new BoundaryException(BoundaryException.GetMessage(samplesToAverage, 1, 127));
@@ -374,7 +374,7 @@ namespace WPILib
             {
                 case EncodingType.K4X:
                     int status = 0;
-                    int value = (int)HALDigital.getEncoderSamplesToAverage(m_encoder, ref status);
+                    int value = (int)HALDigital.GetEncoderSamplesToAverage(m_encoder, ref status);
                     return value;
                 case EncodingType.K2X:
                     return m_counter.GetSamplesToAverage();
@@ -410,7 +410,7 @@ namespace WPILib
             bool activeHigh = (type == IndexingType.ResetWhileHigh) || (type == IndexingType.ResetOnRisingEdge);
             bool edgeSensitive = (type == IndexingType.ResetOnFallingEdge) || (type == IndexingType.ResetOnRisingEdge);
 
-            HALDigital.setEncoderIndexSource(m_encoder, (uint) channel, false, activeHigh, edgeSensitive, ref status);
+            HALDigital.SetEncoderIndexSource(m_encoder, (uint) channel, false, activeHigh, edgeSensitive, ref status);
         }
 
         public void SetIndexSource(int channel)
@@ -425,7 +425,7 @@ namespace WPILib
             bool activeHigh = (type == IndexingType.ResetWhileHigh) || (type == IndexingType.ResetOnRisingEdge);
             bool edgeSensitive = (type == IndexingType.ResetOnFallingEdge) || (type == IndexingType.ResetOnRisingEdge);
 
-            HALDigital.setEncoderIndexSource(m_encoder, (uint) source.GetChannelForRouting(),
+            HALDigital.SetEncoderIndexSource(m_encoder, (uint) source.GetChannelForRouting(),
                 source.GetAnalogTriggerForRouting(), activeHigh, edgeSensitive, ref status);
         }
 

--- a/WPILib/InterruptableSensorBase.cs
+++ b/WPILib/InterruptableSensorBase.cs
@@ -2,7 +2,7 @@
 
 using System;
 using WPILib.Util;
-using HAL_FRC;
+using HAL_Base;
 
 namespace WPILib
 {
@@ -51,9 +51,9 @@ namespace WPILib
             AllocateInterrupts(false);
 
             int status = 0;
-            HALInterrupts.requestInterrupts(m_interrupt, GetModuleForRouting(), (uint)GetChannelForRouting(), GetAnalogTriggerForRouting(), ref status);
+            HALInterrupts.RequestInterrupts(m_interrupt, GetModuleForRouting(), (uint)GetChannelForRouting(), GetAnalogTriggerForRouting(), ref status);
             SetUpSourceEdge(true, false);
-            HALInterrupts.attachInterruptHandler(m_interrupt, function, IntPtr.Zero, ref status);
+            HALInterrupts.AttachInterruptHandler(m_interrupt, function, IntPtr.Zero, ref status);
             //allocate Interupts
         }
 
@@ -67,7 +67,7 @@ namespace WPILib
             AllocateInterrupts(true);
 
             int status = 0;
-            HALInterrupts.requestInterrupts(m_interrupt, GetModuleForRouting(), (uint)GetChannelForRouting(),
+            HALInterrupts.RequestInterrupts(m_interrupt, GetModuleForRouting(), (uint)GetChannelForRouting(),
                 GetAnalogTriggerForRouting(), ref status);
             SetUpSourceEdge(true, false);
             //Setup Source Edge
@@ -86,7 +86,7 @@ namespace WPILib
             m_isSynchronousInterrupt = watcher;
 
             int status = 0;
-            m_interrupt = HALInterrupts.initializeInterrupts(m_interruptIndex, watcher, ref status);
+            m_interrupt = HALInterrupts.InitializeInterrupts(m_interruptIndex, watcher, ref status);
         }
 
         public void CancelInterrupts()
@@ -96,7 +96,7 @@ namespace WPILib
                 throw new InvalidOperationException("The interrupt is not allocated.");
             }
             int status = 0;
-            HALInterrupts.cleanInterrupts(m_interrupt, ref status);
+            HALInterrupts.CleanInterrupts(m_interrupt, ref status);
 
             m_interrupt = IntPtr.Zero;
             s_interrupts.Free((int)m_interruptIndex);
@@ -109,7 +109,7 @@ namespace WPILib
                 throw new InvalidOperationException("The interrupt is not allocated.");
             }
             int status = 0;
-            uint value = HALInterrupts.waitForInterrupt(m_interrupt, timeout, ignorePrevious, ref status);
+            uint value = HALInterrupts.WaitForInterrupt(m_interrupt, timeout, ignorePrevious, ref status);
             return (WaitResult)value;
         }
 
@@ -129,7 +129,7 @@ namespace WPILib
                 throw new InvalidOperationException("You do not need to enable sychronous interrupts");
             }
             int status = 0;
-            HALInterrupts.enableInterrupts(m_interrupt, ref status);
+            HALInterrupts.EnableInterrupts(m_interrupt, ref status);
         }
 
         public void DisableInterrupts()
@@ -143,7 +143,7 @@ namespace WPILib
                 throw new InvalidOperationException("You do not need to enable sychronous interrupts");
             }
             int status = 0;
-            HALInterrupts.disableInterrupts(m_interrupt, ref status);
+            HALInterrupts.DisableInterrupts(m_interrupt, ref status);
         }
 
         public double ReadRisingTimestanp()
@@ -153,7 +153,7 @@ namespace WPILib
                 throw new InvalidOperationException("The interrupt is not allocated.");
             }
             int status = 0;
-            double timestamp = HALInterrupts.readRisingTimestamp(m_interrupt, ref status);
+            double timestamp = HALInterrupts.ReadRisingTimestamp(m_interrupt, ref status);
             return timestamp;
         }
         public double ReadFallingTimestanp()
@@ -163,7 +163,7 @@ namespace WPILib
                 throw new InvalidOperationException("The interrupt is not allocated.");
             }
             int status = 0;
-            double timestamp = HALInterrupts.readFallingTimestamp(m_interrupt, ref status);
+            double timestamp = HALInterrupts.ReadFallingTimestamp(m_interrupt, ref status);
             return timestamp;
         }
 
@@ -172,7 +172,7 @@ namespace WPILib
             if (m_interrupt != IntPtr.Zero)
             {
                 int status = 0;
-                HALInterrupts.setInterruptUpSourceEdge(m_interrupt, risingEdge, fallingEdge, ref status);
+                HALInterrupts.SetInterruptUpSourceEdge(m_interrupt, risingEdge, fallingEdge, ref status);
             }
             else
             {

--- a/WPILib/IterativeRobot.cs
+++ b/WPILib/IterativeRobot.cs
@@ -1,7 +1,7 @@
 ﻿
 
 using System;
-using HAL_FRC;
+using HAL_Base;
 
 namespace WPILib
 {

--- a/WPILib/Jaguar.cs
+++ b/WPILib/Jaguar.cs
@@ -1,5 +1,5 @@
 ﻿using WPILib.Interfaces;
-using HAL_FRC;
+using HAL_Base;
 
 namespace WPILib
 {

--- a/WPILib/Joystick.cs
+++ b/WPILib/Joystick.cs
@@ -2,7 +2,7 @@
 
 using System;
 using WPILib.Interfaces;
-using HAL_FRC;
+using HAL_Base;
 
 namespace WPILib
 {

--- a/WPILib/Notifier.cs
+++ b/WPILib/Notifier.cs
@@ -4,7 +4,7 @@ using System;
 using System.Security.Permissions;
 using WPILib.Interfaces;
 using System.Threading;
-using HAL_FRC;
+using HAL_Base;
 using System.Runtime.InteropServices;
 
 namespace WPILib
@@ -64,7 +64,7 @@ namespace WPILib
                 if (s_refCount == 0)
                 {
                     int status = 0;
-                    s_notifier = HALNotifier.initializeNotifier(_delegate, ref status);
+                    s_notifier = HALNotifier.InitializeNotifier(_delegate, ref status);
                 }
                 s_refCount++;
             }
@@ -76,7 +76,7 @@ namespace WPILib
             if (s_timerQueueHead != null)
             {
                 int status = 0;
-                HALNotifier.updateNotifierAlarm(s_notifier, (uint)(s_timerQueueHead.m_expirationTime * 1e6), ref status);
+                HALNotifier.UpdateNotifierAlarm(s_notifier, (uint)(s_timerQueueHead.m_expirationTime * 1e6), ref status);
             }
         }
 

--- a/WPILib/PWM.cs
+++ b/WPILib/PWM.cs
@@ -2,7 +2,7 @@
 
 using System;
 using WPILib.Util;
-using HAL_FRC;
+using HAL_Base;
 
 namespace WPILib
 {
@@ -41,13 +41,13 @@ namespace WPILib
             _channel = channel;
 
             int status = 0;
-            _port = HALDigital.initializeDigitalPort(HAL.GetPort((byte)channel), ref status);
-            if (!HALDigital.allocatePWMChannel(_port, ref status))
+            _port = HALDigital.InitializeDigitalPort(HAL.GetPort((byte)channel), ref status);
+            if (!HALDigital.AllocatePWMChannel(_port, ref status))
             {
                 throw new AllocationException("PWM channel " + channel + " is already allocated");
             }
 
-            HALDigital.setPWM(_port, 0, ref status);
+            HALDigital.SetPWM(_port, 0, ref status);
 
             _eliminateDeadband = false;
 
@@ -62,9 +62,9 @@ namespace WPILib
         public override void Free()
         {
             int status = 0;
-            HALDigital.setPWM(_port, 0, ref status);
-            HALDigital.freePWMChannel(_port, ref status);
-            HALDigital.freeDIO(_port, ref status);
+            HALDigital.SetPWM(_port, 0, ref status);
+            HALDigital.FreePWMChannel(_port, ref status);
+            HALDigital.FreeDIO(_port, ref status);
         }
 
         public void EnableDeadbandElimination(bool eliminateDeadband)
@@ -85,7 +85,7 @@ namespace WPILib
         {
             int status = 0;
 
-            double loopTime = HALDigital.getLoopTiming(ref status) / (SystemClockTicksPerMicrosecond * 1e3);
+            double loopTime = HALDigital.GetLoopTiming(ref status) / (SystemClockTicksPerMicrosecond * 1e3);
 
             _maxPwm = (int)((max - DefaultPwmCenter) / loopTime + DefaultPwmStepsDown - 1);
             _deadbandMaxPwm = (int)((deadbandMax - DefaultPwmCenter) / loopTime + DefaultPwmStepsDown - 1);
@@ -197,13 +197,13 @@ namespace WPILib
         public void SetRaw(int value)
         {
             int status = 0;
-            HALDigital.setPWM(_port, (ushort)value, ref status);
+            HALDigital.SetPWM(_port, (ushort)value, ref status);
         }
 
         public int GetRaw()
         {
             int status = 0;
-            int value = HALDigital.getPWM(_port, ref status);
+            int value = HALDigital.GetPWM(_port, ref status);
 
             return value;
         }
@@ -215,13 +215,13 @@ namespace WPILib
             switch (mult)
             {
                 case PeriodMultiplier.K1X:
-                    HALDigital.setPWMPeriodScale(_port, 3, ref status);
+                    HALDigital.SetPWMPeriodScale(_port, 3, ref status);
                     break;
                 case PeriodMultiplier.K2X:
-                    HALDigital.setPWMPeriodScale(_port, 1, ref status);
+                    HALDigital.SetPWMPeriodScale(_port, 1, ref status);
                     break;
                 case PeriodMultiplier.K4X:
-                    HALDigital.setPWMPeriodScale(_port, 0, ref status);
+                    HALDigital.SetPWMPeriodScale(_port, 0, ref status);
                     break;
                 default:
                     break;
@@ -231,7 +231,7 @@ namespace WPILib
         protected void SetZeroLatch()
         {
             int status = 0;
-            HALDigital.latchPWMZero(_port, ref status);
+            HALDigital.LatchPWMZero(_port, ref status);
         }
 
         protected int GetMaxPositivePwm()

--- a/WPILib/PowerDistributionPanel.cs
+++ b/WPILib/PowerDistributionPanel.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using WPILib.Interfaces;
-using HAL_FRC;
+using HAL_Base;
 
 namespace WPILib
 {
@@ -17,55 +17,55 @@ namespace WPILib
         public double GetVoltage()
         {
             int status = 0;
-            double value = HALPDP.getPDPVoltage(ref status);
+            double value = HALPDP.GetPDPVoltage(ref status);
             return value;
         }
 
         public double GetTemperature()
         {
             int status = 0;
-            double value = HALPDP.getPDPTemperature(ref status);
+            double value = HALPDP.GetPDPTemperature(ref status);
             return value;
         }
 
         public double GetChannel(int channel)
         {
             int status = 0;
-            double value = HALPDP.getPDPChannelCurrent((byte)channel, ref status);
+            double value = HALPDP.GetPDPChannelCurrent((byte)channel, ref status);
             return value;
         }
 
         public double GetTotalCurrent()
         {
             int status = 0;
-            double value = HALPDP.getPDPTotalCurrent(ref status);
+            double value = HALPDP.GetPDPTotalCurrent(ref status);
             return value;
         }
 
         public double GetTotalPower()
         {
             int status = 0;
-            double value = HALPDP.getPDPTotalPower(ref status);
+            double value = HALPDP.GetPDPTotalPower(ref status);
             return value;
         }
 
         public double GetTotalEnergy()
         {
             int status = 0;
-            double value = HALPDP.getPDPTotalEnergy(ref status);
+            double value = HALPDP.GetPDPTotalEnergy(ref status);
             return value;
         }
 
         public void ResetEnergyTotal()
         {
             int status = 0;
-            HALPDP.resetPDPTotalEnergy(ref status);
+            HALPDP.ResetPDPTotalEnergy(ref status);
         }
 
         public void ClearStickyFaults()
         {
             int status = 0;
-            HALPDP.clearPDPStickyFaults(ref status);
+            HALPDP.ClearPDPStickyFaults(ref status);
         }
 
         

--- a/WPILib/RobotBase.cs
+++ b/WPILib/RobotBase.cs
@@ -2,7 +2,7 @@
 
 using System;
 using System.IO;
-using HAL_FRC;
+using HAL_Base;
 
 namespace WPILib
 {
@@ -100,12 +100,19 @@ namespace WPILib
 
         public static void InitializeHardwareConfiguration()
         {
+            //HAL.IsSimulation = false;
             HAL.Initialize();
         }
 
         private static RobotBase robot;
         public static void main(string robotAssembly, string robotName)
         {
+            if (Environment.OSVersion.Platform == PlatformID.Unix)
+            {
+                HAL.IsSimulation = false;
+            }
+            else
+                HAL.IsSimulation = true;
             InitializeHardwareConfiguration();
             HAL.Report(ResourceType.kResourceType_Language, Instances.kLanguage_CPlusPlus);
             

--- a/WPILib/RobotDrive.cs
+++ b/WPILib/RobotDrive.cs
@@ -2,7 +2,7 @@
 
 using System;
 using WPILib.Interfaces;
-using HAL_FRC;
+using HAL_Base;
 
 namespace WPILib
 {

--- a/WPILib/SampleRobot.cs
+++ b/WPILib/SampleRobot.cs
@@ -2,7 +2,7 @@
 
 using System;
 using System.Threading;
-using HAL_FRC;
+using HAL_Base;
 
 namespace WPILib
 {

--- a/WPILib/Servo.cs
+++ b/WPILib/Servo.cs
@@ -1,4 +1,4 @@
-﻿using HAL_FRC;
+﻿using HAL_Base;
 
 namespace WPILib
 {

--- a/WPILib/Talon.cs
+++ b/WPILib/Talon.cs
@@ -1,5 +1,5 @@
 ﻿using WPILib.Interfaces;
-using HAL_FRC;
+using HAL_Base;
 
 
 namespace WPILib

--- a/WPILib/TalonSRX.cs
+++ b/WPILib/TalonSRX.cs
@@ -1,5 +1,5 @@
 ﻿using WPILib.Interfaces;
-using HAL_FRC;
+using HAL_Base;
 
 namespace WPILib
 {

--- a/WPILib/Timer.cs
+++ b/WPILib/Timer.cs
@@ -2,7 +2,7 @@
 
 using System;
 using System.Threading;
-using HAL_FRC;
+using HAL_Base;
 
 namespace WPILib
 {

--- a/WPILib/Victor.cs
+++ b/WPILib/Victor.cs
@@ -1,5 +1,5 @@
 ﻿using WPILib.Interfaces;
-using HAL_FRC;
+using HAL_Base;
 
 namespace WPILib
 {

--- a/WPILib/VictorSP.cs
+++ b/WPILib/VictorSP.cs
@@ -1,5 +1,5 @@
 ﻿using WPILib.Interfaces;
-using HAL_FRC;
+using HAL_Base;
 
 namespace WPILib
 {

--- a/WPILib/WPILib.csproj
+++ b/WPILib/WPILib.csproj
@@ -24,9 +24,9 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
-    <Optimize>false</Optimize>
+    <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>

--- a/WPILib/WPILib.csproj
+++ b/WPILib/WPILib.csproj
@@ -80,13 +80,9 @@
     <Compile Include="VictorSP.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\HAL-Simulation\HAL-Simulation.csproj" Condition="'$(Configuration)'=='Debug'">
-      <Project>{471a8c6b-aa80-492a-85a3-3ef67fc70988}</Project>
-      <Name>HAL-Simulation</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\HAL-RoboRIO\HAL-RoboRIO.csproj" Condition="'$(Configuration)'=='Release'">
-      <Project>{d41e4184-c699-4f9c-9895-1915638af9d7}</Project>
-      <Name>HAL-RoboRIO</Name>
+    <ProjectReference Include="..\HAL-Base\HAL-Base.csproj">
+      <Project>{bfce384e-ca2a-4604-af76-777da91dafee}</Project>
+      <Name>HAL-Base</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/robotdotnet-wpilib.sln
+++ b/robotdotnet-wpilib.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.21005.1
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WPILib", "WPILib\WPILib.csproj", "{CADAD4A2-D72A-4906-A4F0-2FA2884F3349}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -12,6 +12,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HAL-Simulation", "HAL-Simulation\HAL-Simulation.csproj", "{471A8C6B-AA80-492A-85A3-3EF67FC70988}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HAL-RoboRIO", "HAL-RoboRIO\HAL-RoboRIO.csproj", "{D41E4184-C699-4F9C-9895-1915638AF9D7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HAL-Base", "HAL-Base\HAL-Base.csproj", "{BFCE384E-CA2A-4604-AF76-777DA91DAFEE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -31,6 +33,10 @@ Global
 		{D41E4184-C699-4F9C-9895-1915638AF9D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D41E4184-C699-4F9C-9895-1915638AF9D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D41E4184-C699-4F9C-9895-1915638AF9D7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BFCE384E-CA2A-4604-AF76-777DA91DAFEE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BFCE384E-CA2A-4604-AF76-777DA91DAFEE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BFCE384E-CA2A-4604-AF76-777DA91DAFEE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BFCE384E-CA2A-4604-AF76-777DA91DAFEE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Updates the HAL to use reflection. This allows 2 things. The first is it allows the HAL to be dynamically loaded at runtime, so a change to the HAL doesnt require a rebuild. The second is that it allows the simulator to be loaded dynamically as well if we want. This makes it so we dont have to have both the simulator and the roborio hals in the same namespace, which caused some odd file issues. It makes the code take longer to boot up (about 2-3s), but after that it does not run any slower because it uses delegates which are set on bootup.

We also should be able to create a script to allow us to check and see if the FRC HAL changes, and import those changes automatically into the project, as long as they don't change function names.
