### PR TITLE
Gets NavX basic functionality tested and working.

### DIFF
--- a/WPILib.Extras/NavX/CapabilityFlags.cs
+++ b/WPILib.Extras/NavX/CapabilityFlags.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WPILib.Extras.NavX
+{
+    public enum CapabilityFlags : byte
+    {
+        OMNIMOUNT = 4,
+        VEL_AND_DISP = 64,
+        YAW_RESET = 128,
+        OMNIMOUNT_CONFIG_MASK = 56
+    }
+
+    public enum OpStatus : byte
+    {
+        INITIALIZING = 0,
+        SELFTEST_IN_PROGRESS = 1,
+        ERROR = 2,
+        IMU_AUTOCAL_IN_PROGRESS =3,
+        NORMAL = 4
+    }
+
+    [Flags]
+    public enum CalStatus : byte
+    {
+        IMU_CAL_STATE_MASK = 3,
+        IMU_CAL_INPROGRESS = 0,
+        IMU_CAL_ACCUMULATE = 1,
+        IMU_CAL_COMPLETE = 2,
+        MAG_CAL_COMPLETE = 4,
+        BARO_CAL_COMPLETE = 8
+    }
+
+    [Flags]
+    public enum SelfTestStatus : byte
+    {
+        COMPLETE = 80,
+        GYRO_PASSED = 1,
+        ACCEL_PASSED = 2,
+        MAG_PASSED = 4,
+        BARO_PASSED = 8,
+    }
+}

--- a/WPILib.Extras/NavX/DeviceRegisters.cs
+++ b/WPILib.Extras/NavX/DeviceRegisters.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WPILib.Extras.NavX
+{
+    [Flags]
+    public enum DeviceRegisters : byte
+    {
+        WHOAMI = 0x00,
+        HW_REV = 0x01,
+        FW_VER_MAJOR = 0x02,
+        FW_VER_MINOR = 0x03,
+        UPDATE_RATE_HZ = 0x04,
+        SENSOR_STATUS = 0x10,
+        //TODO: Add the rest of these.
+        CAPATABILITY_FLAGS_L = 0x0B,
+        INTEGRATION_CONTROL = 0x56,
+        YAW = 0x18,
+        FUSED_HEADING = 0x1E,
+
+    }
+}

--- a/WPILib.Extras/NavX/I2cIO.cs
+++ b/WPILib.Extras/NavX/I2cIO.cs
@@ -22,16 +22,16 @@ namespace WPILib.Extras.NavX
 
         public byte[] Read(byte readSize, DeviceRegisters deviceRegister)
         {
-            m_i2c.LVWrite((byte)deviceRegister, new byte[] { readSize });
+            m_i2c.LvWrite((byte)deviceRegister, new byte[] { readSize });
             byte[] buffer = new byte[readSize];
-            m_i2c.LVRead(new byte[0], readSize, ref buffer);
+            m_i2c.LvRead(new byte[0], readSize, ref buffer);
             return buffer;
         }
 
         public void Write(DeviceRegisters deviceRegister, byte[] message)
         {
             byte reg = (byte)((byte)deviceRegister | 0x80);
-            m_i2c.LVWrite(reg, message);
+            m_i2c.LvWrite(reg, message);
         }
     }
 }

--- a/WPILib.Extras/NavX/I2cIO.cs
+++ b/WPILib.Extras/NavX/I2cIO.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WPILib.Extras.NavX
+{
+    internal class I2cIO :IIo
+    {
+        private readonly I2C m_i2c;
+
+        public I2cIO(I2C.Port port)
+        {
+            m_i2c = new I2C(port, 0x32);
+        }
+
+        public void Dispose()
+        {
+            m_i2c.Dispose();
+        }
+
+        public byte[] Read(byte readSize, DeviceRegisters deviceRegister)
+        {
+            m_i2c.LVWrite((byte)deviceRegister, new byte[] { readSize });
+            byte[] buffer = new byte[readSize];
+            m_i2c.LVRead(new byte[0], readSize, ref buffer);
+            return buffer;
+        }
+
+        public void Write(DeviceRegisters deviceRegister, byte[] message)
+        {
+            byte reg = (byte)((byte)deviceRegister | 0x80);
+            m_i2c.LVWrite(reg, message);
+        }
+    }
+}

--- a/WPILib.Extras/NavX/IIo.cs
+++ b/WPILib.Extras/NavX/IIo.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WPILib.Extras.NavX
+{
+    internal interface IIo : IDisposable
+    {
+        byte[] Read(byte readSize, DeviceRegisters deviceRegister);
+        void Write(DeviceRegisters deviceRegister, byte[] message);
+    }
+}

--- a/WPILib.Extras/NavX/NavXMxp.cs
+++ b/WPILib.Extras/NavX/NavXMxp.cs
@@ -1,0 +1,314 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace WPILib.Extras.NavX
+{
+    public struct NavXBoardInfo
+    {
+        public byte WhoAmI { get; private set; }
+        public byte BoardRevision { get; private set; }
+        public byte FirmwareMajorVersion { get; private set; }
+        public byte FirmwareMinorVersion { get; private set; }
+
+        public bool BoardYawAxisUp { get; private set; }
+        public byte BoardYawAxis { get; private set; }
+
+        public bool Omnimount { get; private set; }
+        public bool YawReset { get; private set; }
+        public bool VelAndDisp { get; private set; }
+
+        internal NavXBoardInfo(byte whoami, byte rev, byte major, byte minor,
+            bool yawup, byte yawAxis, bool omni, bool yreset, bool veldisp)
+        {
+            WhoAmI = whoami;
+            BoardRevision = rev;
+            FirmwareMajorVersion = major;
+            FirmwareMinorVersion = minor;
+            BoardYawAxisUp = yawup;
+            BoardYawAxis = yawAxis;
+            Omnimount = omni;
+            YawReset = yreset;
+            VelAndDisp = veldisp;
+        }
+    }
+
+    public struct NavXStatus
+    {
+        public byte UpdateRateHz { get; private set; }
+        public byte AccelerometerFullScaleRange { get; private set; }
+        public ushort GyroFullScaleRange { get; private set; }
+
+        public OpStatus OperationStatus { get; private set; }
+        public CalStatus CalibrationStatus { get; private set; }
+
+        public byte SelftestStatus { get; private set; }
+
+        public bool Moving { get; private set; }
+        public bool YawStable { get; private set; }
+        public bool MagDisturbance { get; private set; }
+        public bool AltitudeValid { get; private set; }
+        public bool SealevelPressureSet { get; private set; }
+        public bool FusedHeadingValid { get; private set; }
+
+        internal NavXStatus(byte upRate, byte acc, ushort gyro, OpStatus op, CalStatus cal,
+            byte self, bool moving, bool yaw, bool mag, bool alt, bool sea, bool fused)
+        {
+            UpdateRateHz = upRate;
+            AccelerometerFullScaleRange = acc;
+            GyroFullScaleRange = gyro;
+            OperationStatus = op;
+            CalibrationStatus = cal;
+            SelftestStatus = self;
+            Moving = moving;
+            YawStable = yaw;
+            MagDisturbance = mag;
+            AltitudeValid = alt;
+            SealevelPressureSet = sea;
+            FusedHeadingValid = fused;
+        }
+    }
+
+    public class NavXMxp : IDisposable
+    {
+        IIo m_io;
+
+        private bool Initialize()
+        {
+            Thread.Sleep(250);
+            m_io.Read(2, DeviceRegisters.WHOAMI);
+            m_io.Read(2, DeviceRegisters.WHOAMI);
+            Thread.Sleep(250);
+            bool boardInfoValid;
+            GetBoardInfo(out boardInfoValid);
+            Thread.Sleep(250);
+            bool statusValid;
+            GetStatus(out statusValid);
+            Thread.Sleep(250);
+            m_io.Write(DeviceRegisters.UPDATE_RATE_HZ, new byte[]{(byte)m_updateRateHz});
+            return boardInfoValid && statusValid;
+
+        }
+
+        public NavXMxp(SPI.Port port, int updateRateHz = 50)
+        {
+            if (updateRateHz > 60)
+            {
+                updateRateHz = 60;
+            }
+            if (updateRateHz < 4)
+            {
+                updateRateHz = 4;
+            }
+            m_updateRateHz = updateRateHz;
+            m_io = new SpiIO(port);
+            Initialize();
+        }
+
+        public NavXMxp(I2C.Port port, int updateRateHz = 50)
+        {
+            if (updateRateHz > 60)
+            {
+                updateRateHz = 60;
+            }
+            if (updateRateHz < 4)
+            {
+                updateRateHz = 4;
+            }
+            m_updateRateHz = updateRateHz;
+            m_io = new I2cIO(port);
+            Initialize();
+        }
+
+        public void Dispose()
+        {
+            m_io.Dispose();
+        }
+
+        long m_lastSampleTimeStamp = 0;
+        int m_updateRateHz = 50;
+        bool m_lastSampleValid = true;
+
+        byte[] m_cacheArray = new byte[0x6f];
+
+        NavXBoardInfo m_boardInfo;
+        NavXStatus m_status;
+
+        private ushort Combine(byte high, byte low)
+        {
+            return (ushort)(low << 8 | high);
+        }
+
+        private byte[] ReadCached(byte readSize, DeviceRegisters register, out bool valid)
+        {
+            var currentStamp = Utility.GetFPGATime();
+            var deltaStamp = currentStamp - m_lastSampleTimeStamp;
+            var updateRate = 1000 / m_updateRateHz;
+            bool timespampExpired = deltaStamp * 1000 >= updateRate;
+
+            byte[] read;
+
+
+            if (timespampExpired)
+            {
+                byte readS = m_boardInfo.VelAndDisp ? (byte)0x6F : (byte)0x55;
+
+                read = Read(readS, 0, out m_lastSampleValid);
+                m_lastSampleTimeStamp = currentStamp;
+            }
+            else
+            {
+                read = m_cacheArray;
+            }
+
+            valid = m_lastSampleValid;
+            if (!m_lastSampleValid) return new byte[readSize];
+            m_cacheArray = read;
+
+            byte[] retVal = new byte[readSize];
+            Array.Copy(read, (int)register, retVal, 0, readSize);
+            return retVal;
+        }
+
+        private byte[] Read(byte readSize, DeviceRegisters register, out bool valid)
+        {
+            byte[] retVal = m_io.Read(readSize, register);
+            valid = retVal.Length > 0;
+            return retVal;
+        }
+
+        public NavXBoardInfo GetBoardInfo(out bool valid)
+        {
+            byte[] read = ReadCached(2, DeviceRegisters.CAPATABILITY_FLAGS_L, out valid);
+
+            byte read0 = read[0];
+
+            bool velAndDisp = (read0 & (byte)CapabilityFlags.VEL_AND_DISP) != 0;
+            bool omnimount = (read0 & (byte)CapabilityFlags.OMNIMOUNT) != 0;
+            bool yawReset = (read0 & (byte)CapabilityFlags.YAW_RESET) != 0;
+
+            bool boardYawAxisUp = true;
+            byte boardYawAxis = 2;
+
+            if (omnimount)
+            {
+                boardYawAxisUp = (read0 & 0x08) != 0;
+                int mask = read0 & (byte)CapabilityFlags.OMNIMOUNT_CONFIG_MASK;
+
+                boardYawAxis = (byte)(mask / 16);
+            }
+
+            byte[] whoamiRet = ReadCached(4, DeviceRegisters.WHOAMI, out valid);
+
+            if (whoamiRet == null)
+            {
+                whoamiRet = new byte[4];
+            }
+
+            valid = m_lastSampleValid;
+            var info =  new NavXBoardInfo(whoamiRet[0], whoamiRet[1], whoamiRet[2], whoamiRet[3],
+                boardYawAxisUp, boardYawAxis, omnimount, yawReset, velAndDisp);
+            m_boardInfo = info;
+            return info;
+        }
+
+        IEnumerable<bool> GetBits(byte b)
+        {
+            for (int i = 0; i < 16; i++)
+            {
+                yield return (b & 0x80) != 0;
+                b *= 2;
+            }
+        }
+
+        public NavXStatus GetStatus(out bool valid)
+        {
+            bool UpdateRateReadValid;
+            byte[] read = ReadCached(8, DeviceRegisters.UPDATE_RATE_HZ, out UpdateRateReadValid);
+            bool SensorReadValid;
+            byte[] sensorStatusRead = ReadCached(2, DeviceRegisters.SENSOR_STATUS, out SensorReadValid);
+
+
+
+            valid = UpdateRateReadValid && SensorReadValid;
+
+            int calStatus = read[5] & (byte)SelfTestStatus.COMPLETE;
+            int self = read[6] & (byte)CalStatus.IMU_CAL_STATE_MASK;
+
+            var bits = GetBits(sensorStatusRead[0]).ToList();
+
+            var status = new NavXStatus(read[0], read[1], Combine(read[2], read[3]), (OpStatus)read[4], (CalStatus)calStatus, 
+                (byte)self, bits[0], bits[1], bits[2], bits[3], bits[4], bits[5]);
+            m_status = status;
+            return status;
+        }
+
+        public double Yaw { get; private set; }
+
+        public void ZeroDisplacement()
+        {
+            m_io.Write(DeviceRegisters.INTEGRATION_CONTROL, new byte[] {0x3f});
+        }
+
+        public void ZeroYaw()
+        {
+            if (m_boardInfo.YawReset)
+            {
+                //Board supports yaw reset
+                m_io.Write(DeviceRegisters.INTEGRATION_CONTROL, new byte[] { 128 });
+            }
+            else
+            {
+                Yaw = 0;
+                bool valid;
+                var yprh = GetYPRH(out valid);
+                Yaw = valid ? yprh.Yaw : 0;
+            }
+        }
+
+        public double GetFusedHeading()
+        {
+            bool valid;
+            byte[] read = ReadCached(2, DeviceRegisters.FUSED_HEADING, out valid);
+            return Combine(read[0], read[1])/ 100.0;
+        }
+
+        public YPRH GetYPRH(out bool valid)
+        {
+            byte[] read = ReadCached(8, DeviceRegisters.YAW, out valid);
+            int yaw = (short)Combine(read[0], read[1]);
+            int pitch = (short)Combine(read[2], read[3]);
+            int roll = (short)Combine(read[4], read[5]);
+            int heading = Combine(read[6], read[7]);
+
+            double[] yawArray = new double[] { Yaw, Yaw, Yaw};
+
+            yaw = yaw / 100;
+            pitch = pitch / 100;
+            roll = roll / 100;
+
+            heading = heading / 100;
+
+            return new YPRH(yaw - Yaw, pitch - Yaw, roll - Yaw, heading);
+        }
+    }
+
+    public struct YPRH
+    {
+        public double Yaw { get; private set; }
+        public double Pitch { get; private set; }
+        public double Roll { get; private set; }
+        public double Heading { get; private set; }
+
+        public YPRH(double yaw, double pitch, double roll, double heading)
+        {
+            Yaw = yaw;
+            Pitch = pitch;
+            Roll = roll;
+            Heading = heading;
+        }
+    }
+}

--- a/WPILib.Extras/NavX/SpiIO.cs
+++ b/WPILib.Extras/NavX/SpiIO.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WPILib.Extras.NavX
+{
+    internal class SpiIO :IIo
+    {
+        public byte[] CalculateCrc(byte[] message, out byte crc)
+        {
+            crc = CalculateCrc(message);
+            byte[] messageWithCrc = new byte[message.Length + 1];
+            Array.Copy(message, messageWithCrc, message.Length);
+            messageWithCrc[message.Length] = crc;
+            return messageWithCrc;
+        }
+
+        public byte CalculateCrc(byte[] message)
+        {
+            byte i = 0, j = 0;
+            byte crc = 0;
+            for (i = 0; i < message.Length; ++i)
+            {
+                crc ^= message[i];
+                for (j = 0; j < 8; ++j)
+                {
+                    if ((crc & 1) != 0)
+                    {
+                        crc ^= 0x91;
+                    }
+                    crc >>= 1;
+                }
+            }
+            return crc;
+        }
+
+        private readonly SPI m_spi;
+
+        public SpiIO(SPI.Port port)
+        {
+            m_spi = new SPI(port);
+            m_spi.SetClockRate(2000000);
+        }
+
+        public void Dispose()
+        {
+            m_spi.Dispose();
+        }
+
+        public byte[] Read(DeviceRegisters deviceRegister, byte readSize)
+        {
+            byte crc;
+            byte[] toWrite = CalculateCrc(new[] {(byte)deviceRegister, readSize}, out crc);
+            m_spi.Write(toWrite, toWrite.Length);
+            byte[] readBytes = new byte[readSize + 1];
+            m_spi.Read(false, readBytes, readBytes.Length);
+
+            crc = readBytes[readBytes.Length];
+            
+            byte[] readBytesWithoutCrc = new byte[readBytes.Length - 1];
+            Array.Copy(readBytes, readBytesWithoutCrc, readBytesWithoutCrc.Length);
+
+            byte calcCrc = CalculateCrc(readBytesWithoutCrc);
+
+            if (crc != calcCrc) return null;
+
+            return readBytesWithoutCrc;
+        }
+
+        public void Write(DeviceRegisters deviceRegister, byte[] message)
+        {
+            byte reg = (byte)((byte)deviceRegister | 0x80);
+            byte[] messageToCrc = new byte[message.Length + 1];
+            messageToCrc[0] = reg;
+            Array.Copy(message, 0, messageToCrc, 1, message.Length);
+            byte crc;
+            byte[] messageWithCrc = CalculateCrc(messageToCrc, out crc);
+
+            m_spi.Write(messageWithCrc, messageWithCrc.Length);
+        }
+    }
+}

--- a/WPILib.Extras/NavX/SpiIO.cs
+++ b/WPILib.Extras/NavX/SpiIO.cs
@@ -19,12 +19,12 @@ namespace WPILib.Extras.NavX
 
         public byte CalculateCrc(byte[] message)
         {
-            byte i = 0, j = 0;
-            byte crc = 0;
-            for (i = 0; i < message.Length; ++i)
+            byte i, j, crc = 0;
+
+            for (i = 0; i < message.Length; i++)
             {
                 crc ^= message[i];
-                for (j = 0; j < 8; ++j)
+                for (j = 0; j < 8; j++)
                 {
                     if ((crc & 1) != 0)
                     {
@@ -41,7 +41,11 @@ namespace WPILib.Extras.NavX
         public SpiIO(SPI.Port port)
         {
             m_spi = new SPI(port);
-            m_spi.SetClockRate(2000000);
+            m_spi.SetClockRate(500000);
+            m_spi.SetMSBFirst();
+            m_spi.SetSampleDataOnFalling();
+            m_spi.SetClockActiveLow();
+            m_spi.SetChipSelectActiveLow();
         }
 
         public void Dispose()
@@ -56,12 +60,9 @@ namespace WPILib.Extras.NavX
             m_spi.Write(toWrite, toWrite.Length);
             byte[] readBytes = new byte[readSize + 1];
             m_spi.Read(false, readBytes, readBytes.Length);
-
-            crc = readBytes[readBytes.Length];
-            
+            crc = readBytes[readBytes.Length - 1];
             byte[] readBytesWithoutCrc = new byte[readBytes.Length - 1];
             Array.Copy(readBytes, readBytesWithoutCrc, readBytesWithoutCrc.Length);
-
             byte calcCrc = CalculateCrc(readBytesWithoutCrc);
 
             if (crc != calcCrc) return null;

--- a/WPILib.Extras/NavX/SpiIO.cs
+++ b/WPILib.Extras/NavX/SpiIO.cs
@@ -49,7 +49,7 @@ namespace WPILib.Extras.NavX
             m_spi.Dispose();
         }
 
-        public byte[] Read(DeviceRegisters deviceRegister, byte readSize)
+        public byte[] Read(byte readSize, DeviceRegisters deviceRegister)
         {
             byte crc;
             byte[] toWrite = CalculateCrc(new[] {(byte)deviceRegister, readSize}, out crc);

--- a/WPILib.Extras/WPILib.Extras.csproj
+++ b/WPILib.Extras/WPILib.Extras.csproj
@@ -69,6 +69,12 @@
     <Compile Include="AttributedCommandModel\RunCommandOnJoystickAttribute.cs" />
     <Compile Include="AttributedCommandModel\RunCommandOnNetworkKeyAttribute.cs" />
     <Compile Include="LabVIEWRobot.cs" />
+    <Compile Include="NavX\CapabilityFlags.cs" />
+    <Compile Include="NavX\DeviceRegisters.cs" />
+    <Compile Include="NavX\I2cIO.cs" />
+    <Compile Include="NavX\IIo.cs" />
+    <Compile Include="NavX\NavXMxp.cs" />
+    <Compile Include="NavX\SpiIO.cs" />
     <Compile Include="XboxController.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
@@ -85,6 +91,7 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
I don't have time right now to add the rest of the commands, but basic functionality is tested and working, with both I2C and SPI. Does not use cached reads, however I belive that those are much slower then individual reads. Plus I2C on the HAL does not support buffers larger then 8. So SPI is the preferred choice, and what we will be using.
