### PR TITLE
Driver Station Performance Improvements

### DIFF
--- a/WPILib.Tests/TestDriverStation.cs
+++ b/WPILib.Tests/TestDriverStation.cs
@@ -256,7 +256,7 @@ namespace WPILib.Tests
                 }
             };
             DriverStationHelper.UpdateData();
-            Thread.Sleep(10);
+            Thread.Sleep(150);
             int buttonCount = DriverStation.Instance.GetStickButtonCount(0);
             Assert.That(buttonCount, Is.EqualTo(numButtons));
             for (int i = 0; i < buttonCount; i++)
@@ -271,7 +271,7 @@ namespace WPILib.Tests
                 buttons[i] = true;
             }
             DriverStationHelper.UpdateData();
-            Thread.Sleep(10);
+            Thread.Sleep(150);
             for (int i = 0; i < buttonCount; i++)
             {
                 bool button = DriverStation.Instance.GetStickButton(0, (byte)(i + 1));
@@ -301,7 +301,7 @@ namespace WPILib.Tests
                 }
             };
             DriverStationHelper.UpdateData();
-            Thread.Sleep(10);
+            Thread.Sleep(150);
             int axesCount = DriverStation.Instance.GetStickAxisCount(0);
             Assert.That(axesCount, Is.EqualTo(numAxes));
             for (int i = 0; i < axesCount; i++)
@@ -316,7 +316,7 @@ namespace WPILib.Tests
                 axes[i] = -.598;
             }
             DriverStationHelper.UpdateData();
-            Thread.Sleep(10);
+            Thread.Sleep(150);
             for (int i = 0; i < axesCount; i++)
             {
                 double axis = DriverStation.Instance.GetStickAxis(0, i);

--- a/WPILib.Tests/WPILib.Tests.csproj
+++ b/WPILib.Tests/WPILib.Tests.csproj
@@ -28,7 +28,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <PlatformTarget>x86</PlatformTarget>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
The old driver station code had some performance issues. It would cache the data under lock, which would take about 5ms. In addition, only 1 thread could read from the cache at one time, which could be a problem. So the code was changed to use a ReaderWriterLockSlim, as writes are called much less then reads. The second commit changes the code to use a cache to pull the data from the HAL, and then grabs the lock and does a reference change, which can happen much quicker.
