### PR TITLE
Fixed typo in GetSubTables() causing error

### DIFF
--- a/src/ntcore/NetworkTable.cs
+++ b/src/ntcore/NetworkTable.cs
@@ -185,7 +185,7 @@ namespace NetworkTables
             {
                 var relativeKey = info.Name.AsSpan().Slice(prefixLen);
                 int endSubTable = relativeKey.IndexOf(PathSeparator);
-                if (endSubTable == 1)
+                if (endSubTable == -1)
                 {
                     continue;
                 }


### PR DESCRIPTION
Resolves the following error when calling `GetSubTables` on a `NetworkTable` object:
```
ArgumentOutOfRangeException: Specified argument was out of the range of valid values.
```

Reproduction:
```cs
using FRC.NetworkTables;
...
NetworkTableInstance.GetTable("SmartDashboard").GetSubTables(); //This causes the error
```

