### PR TITLE
Fixed typo in NetworkTable.GetKeys() causing error

### DIFF
--- a/src/ntcore/NetworkTable.cs
+++ b/src/ntcore/NetworkTable.cs
@@ -158,7 +158,7 @@ namespace NetworkTables
         public HashSet<string> GetKeys(NtType types)
         {
             HashSet<string> keys = new HashSet<string>();
-            int prefixLen = -Path.Length + 1;
+            int prefixLen = Path.Length + 1;
             foreach (var info in Instance.GetEntryInfo(m_pathWithSep, types))
             {
                 var relativeKey = info.Name.AsSpan().Slice(prefixLen);


### PR DESCRIPTION
Resolves the following error when calling `GetKeys` on a `NetworkTable` object:
```
ArgumentOutOfRangeException: Specified argument was out of the range of valid values.
```

Reproduction:
```cs
using FRC.NetworkTables;
...
NetworkTableInstance.Default.GetTable("SmartDashboard").GetKeys(); //This causes the error
```